### PR TITLE
Remove redundant file logging references

### DIFF
--- a/src/agent/config/logging.py
+++ b/src/agent/config/logging.py
@@ -2,7 +2,7 @@
 Logging configuration module for AgentUp.
 
 This module provides centralized logging configuration using structlog for structured logging
-with support for multiple output formats (text, JSON), different backends (console, file),
+with support for multiple output formats (text, JSON), console output,
 and integration with FastAPI/uvicorn.
 """
 

--- a/src/agent/config/models.py
+++ b/src/agent/config/models.py
@@ -147,14 +147,6 @@ class LoggingConfig(BaseModel):
         "colors": True,
     }
 
-    file: dict[str, Any] = {
-        "enabled": False,
-        "path": "logs/agent.log",
-        "rotation": "100 MB",
-        "retention": "1 week",
-        "compression": True,
-    }
-
     # Advanced configuration
     correlation_id: bool = True
     request_logging: bool = True

--- a/src/agent/templates/config/agentup.yml.j2
+++ b/src/agent/templates/config/agentup.yml.j2
@@ -328,16 +328,6 @@ logging:
     enabled: {{ console_logging | default(true) }}
     colors: {{ console_colors | default(true) }}
 
-  # File logging
-  file:
-    enabled: {{ file_logging | default(false) }}
-{% if file_logging %}
-    path: "{{ log_file_path | default('logs/' + project_name_snake + '.log') }}"
-    rotation: "{{ log_rotation | default('100 MB') }}"
-    retention: "{{ log_retention | default('7 days') }}"
-    compression: {{ log_compression | default(false) }}
-{% endif %}
-
   # Advanced features
   correlation_id: {{ correlation_id | default(false) }}
   request_logging: {{ request_logging | default(false) }}

--- a/src/agent/templates/config/agentup_full.yml.j2
+++ b/src/agent/templates/config/agentup_full.yml.j2
@@ -339,14 +339,6 @@ logging:
     enabled: true
     colors: false  # Disable colors in production
 
-  # File logging enabled for production
-  file:
-    enabled: true
-    path: "logs/{{ project_name_snake }}.log"
-    rotation: "100 MB"
-    retention: "30 days"
-    compression: true
-
   # Advanced features for production
   correlation_id: true        # Essential for distributed tracing
   request_logging: true       # Important for monitoring and debugging

--- a/src/agent/templates/config/agentup_minimal.yml.j2
+++ b/src/agent/templates/config/agentup_minimal.yml.j2
@@ -274,10 +274,6 @@ logging:
     enabled: true
     colors: true
 
-  # File logging disabled for minimal template
-  file:
-    enabled: false
-
   # Basic features for minimal template
   correlation_id: false       # Disabled for simplicity
   request_logging: false      # Disabled for simplicity


### PR DESCRIPTION
## 📝 Description

I never got around to implementing file logging, and i question its value in the first place. It was originally sketched out from when I was debugging middleware.
