### PR TITLE
Removed: Non-functional plugin_specific_limits configuration

### DIFF
--- a/docs/security/bearer-tokens.md
+++ b/docs/security/bearer-tokens.md
@@ -75,12 +75,7 @@ Bearer token authentication works  with context-aware middleware:
 # Context-aware middleware configuration
 middleware:
   - name: rate_limited
-    params:
-      # Plugin-specific rate limits based on authentication
-      plugin_specific_limits:
-        local: 200      # Higher rate for authenticated local plugins
-        network: 60     # Conservative rate for network operations
-        ai_function: 30 # Careful rate limiting for AI operations
+    params: {}
   - name: cached
     params:
       # Authentication-aware caching

--- a/src/agent/generator.py
+++ b/src/agent/generator.py
@@ -617,14 +617,6 @@ Always be helpful, accurate, and maintain a friendly tone. You are designed to a
             "name": "rate_limited",
             "params": {
                 "requests_per_minute": base_rpm,
-                # Plugin-specific rate limiting
-                "plugin_specific_limits": {
-                    "local": base_rpm * 2,  # Higher rate for local plugins
-                    "network": base_rpm // 2,  # Lower rate for network plugins
-                    "hybrid": base_rpm,  # Standard rate for hybrid plugins
-                    "ai_function": base_rpm // 3,  # Much lower rate for AI functions
-                    "core": base_rpm * 3,  # Higher rate for core functions
-                },
             },
         }
 

--- a/src/agent/templates/config/agentup.yml.j2
+++ b/src/agent/templates/config/agentup.yml.j2
@@ -255,12 +255,6 @@ middleware:
   - name: rate_limited
     params:
       requests_per_minute: {{ rate_limit_rpm | default(60) }}
-      # Plugin-specific rate limiting
-      plugin_specific_limits:
-        local: {{ rate_limit_rpm | default(60) }}           # Standard rate for local plugins
-        network: {{ (rate_limit_rpm | default(60)) // 2 }}  # Lower rate for network plugins
-        hybrid: {{ rate_limit_rpm | default(60) }}          # Standard rate for hybrid plugins
-        ai_function: {{ (rate_limit_rpm | default(60)) // 3 }}  # Much lower rate for AI functions
 {% endif %}
 {% if 'retry' in feature_config.get('middleware', []) %}
   - name: retryable

--- a/src/agent/templates/config/agentup_full.yml.j2
+++ b/src/agent/templates/config/agentup_full.yml.j2
@@ -257,13 +257,6 @@ middleware:
     params:
       requests_per_minute: 120  # Higher rate for enterprise
       burst_size: 30           # Allow burst traffic
-      # Enterprise plugin-specific rate limiting
-      plugin_specific_limits:
-        local: 200             # High rate for local plugins
-        network: 60            # Moderate rate for network plugins
-        hybrid: 120            # Standard enterprise rate
-        ai_function: 30        # Conservative rate for AI operations
-        core: 500              # Very high rate for core functions
 {% endif %}
 {% if has_middleware and 'retry' in feature_config.get('middleware', []) %}
   - name: retryable

--- a/src/agent/templates/config/agentup_minimal.yml.j2
+++ b/src/agent/templates/config/agentup_minimal.yml.j2
@@ -192,13 +192,6 @@ middleware:
   - name: rate_limited
     params:
       requests_per_minute: 60  # Standard rate for minimal template
-      # Plugin-specific rate limiting
-      plugin_specific_limits:
-        local: 120             # Higher rate for local plugins
-        network: 30            # Lower rate for network plugins
-        hybrid: 60             # Standard rate for hybrid plugins
-        ai_function: 20        # Lower rate for AI functions
-        core: 180              # Higher rate for core functions
 {% endif %}
 {% if has_middleware and 'retry' in feature_config.get('middleware', []) %}
   - name: retryable


### PR DESCRIPTION
The middleware override system now provides better functionality, allowing each plugin to define its own complete middleware stack, modify specific parameters, or disable middleware entirely - exactly what plugin_specific_limits was supposed to do but never actually implemented.

Therefore, in ye bin ye go thy swine. You never did nowt for me anyhoo.
