### PR TITLE
Prevent excessive card reloading

### DIFF
--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -86,7 +86,8 @@ def create_agent_card(extended: bool = False) -> AgentCard:
 
     # Create a hash of the configuration to detect changes
     config_str = str(sorted(config.items()))
-    current_config_hash = hashlib.md5(config_str.encode()).hexdigest()
+    # Bandit issue: B324 - Using hashlib.md5() is acceptable here for caching purposes
+    current_config_hash = hashlib.md5(config_str.encode()).hexdigest()  # nosec
 
     # Check if we can use cached version
     if _cached_config_hash == current_config_hash:

--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -19,7 +19,6 @@ from a2a.types import (
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from agent.config import load_config
 from agent.config.models import (
     AgentCapabilities,
     AgentCard,
@@ -36,6 +35,7 @@ from agent.push.types import (
     listTaskPushNotificationConfigResponse,
 )
 from agent.security import AuthContext, get_auth_result, protected
+from agent.services.config import ConfigurationManager
 
 # Setup logger
 logger = structlog.get_logger(__name__)
@@ -44,6 +44,11 @@ logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 # Configuration will be loaded when needed
+
+# Agent card caching
+_cached_agent_card: AgentCard | None = None
+_cached_extended_agent_card: AgentCard | None = None
+_cached_config_hash: str | None = None
 
 # Task storage
 task_storage: dict[str, dict[str, Any]] = {}
@@ -71,18 +76,31 @@ def create_agent_card(extended: bool = False) -> AgentCard:
     Args:
         extended: If True, include plugins with visibility="extended" in addition to public plugins
     """
+    import hashlib
 
-    config = load_config(configure_logging=False)  # Don't reconfigure logging
+    global _cached_agent_card, _cached_extended_agent_card, _cached_config_hash
+
+    # Get configuration from the cached ConfigurationManager
+    config_manager = ConfigurationManager()
+    config = config_manager.config
+
+    # Create a hash of the configuration to detect changes
+    config_str = str(sorted(config.items()))
+    current_config_hash = hashlib.md5(config_str.encode()).hexdigest()
+
+    # Check if we can use cached version
+    if _cached_config_hash == current_config_hash:
+        if extended and _cached_extended_agent_card is not None:
+            return _cached_extended_agent_card
+        elif not extended and _cached_agent_card is not None:
+            return _cached_agent_card
+
+    # Cache miss - regenerate agent card
     agent_info = config.get("agent", {})
     plugins = config.get("plugins", [])
 
-    # Debug: Log plugins to understand the validation error
-    import logging
-
-    logger = logging.getLogger(__name__)
-    logger.info(f"Loaded {len(plugins)} plugins from config")
-    for i, plugin in enumerate(plugins):
-        logger.info(f"Plugin {i}: id={plugin.get('plugin_id')}, desc={plugin.get('description')}")
+    # Only log plugins when actually regenerating (cache miss)
+    logger.debug(f"Regenerating agent card - loaded {len(plugins)} plugins from config")
 
     # Convert plugins to A2A Skill format based on visibility
     agent_skills = []
@@ -192,6 +210,13 @@ def create_agent_card(extended: bool = False) -> AgentCard:
         supportsAuthenticatedExtendedCard=has_extended_plugins,
     )
 
+    # Update cache
+    _cached_config_hash = current_config_hash
+    if extended:
+        _cached_extended_agent_card = agent_card
+    else:
+        _cached_agent_card = agent_card
+
     return agent_card
 
 
@@ -224,12 +249,12 @@ async def get_task_status(task_id: str, request: Request) -> JSONResponse:
 @router.get("/health")
 async def health_check() -> JSONResponse:
     """Basic health check endpoint."""
-    config = load_config(configure_logging=False)
+    config_manager = ConfigurationManager()
     return JSONResponse(
         status_code=200,
         content={
             "status": "healthy",
-            "agent": config.get("project_name", "Agent"),
+            "agent": config_manager.get("project_name", "Agent"),
             "timestamp": datetime.now().isoformat(),
         },
     )

--- a/tests/test_core/test_api.py
+++ b/tests/test_core/test_api.py
@@ -112,24 +112,25 @@ class TestAgentCard:
 
         # Clear any existing cache
         import agent.api.routes
+
         agent.api.routes._cached_agent_card = None
         agent.api.routes._cached_extended_agent_card = None
         agent.api.routes._cached_config_hash = None
 
         # First call should create the card
         card1 = create_agent_card()
-        
+
         # Second call should return cached version
         card2 = create_agent_card()
-        
+
         # Should be the same instance (cached)
         assert card1 is card2
         assert card1.name == "CachedAgent"
-        
+
         # Test extended cards are cached separately
         extended_card1 = create_agent_card(extended=True)
         extended_card2 = create_agent_card(extended=True)
-        
+
         assert extended_card1 is extended_card2
 
 

--- a/tests/test_core/test_api.py
+++ b/tests/test_core/test_api.py
@@ -34,15 +34,16 @@ from agent.config.models import (
 class TestAgentCard:
     """Test agent card creation."""
 
-    @patch("agent.api.routes.load_config")
-    def test_create_agent_card_minimal(self, mock_load_config):
+    @patch("agent.api.routes.ConfigurationManager")
+    def test_create_agent_card_minimal(self, mock_config_manager):
         """Test creating agent card with minimal configuration."""
-        mock_load_config.return_value = {
+        mock_config = {
             "project_name": "TestAgent",
             "description": "Test Agent Description",
             "agent": {"name": "TestAgent", "description": "Test Agent", "version": "1.0.0"},
             "skills": [],
         }
+        mock_config_manager.return_value.config = mock_config
 
         card = create_agent_card()
 
@@ -58,10 +59,10 @@ class TestAgentCard:
         assert card.capabilities.pushNotifications is False
         assert card.capabilities.stateTransitionHistory is True
 
-    @patch("agent.api.routes.load_config")
-    def test_create_agent_card_with_skills(self, mock_load_config):
+    @patch("agent.api.routes.ConfigurationManager")
+    def test_create_agent_card_with_skills(self, mock_config_manager):
         """Test creating agent card with skills."""
-        mock_load_config.return_value = {
+        mock_config = {
             "agent": {"name": "SkillfulAgent", "description": "Agent with skills", "version": "2.0.0"},
             "plugins": [
                 {
@@ -74,6 +75,7 @@ class TestAgentCard:
                 }
             ],
         }
+        mock_config_manager.return_value.config = mock_config
 
         card = create_agent_card()
 
@@ -81,14 +83,15 @@ class TestAgentCard:
         assert card.skills[0].id == "chat"
         assert card.skills[0].name == "Chat"
 
-    @patch("agent.api.routes.load_config")
-    def test_create_agent_card_with_security_enabled(self, mock_load_config):
+    @patch("agent.api.routes.ConfigurationManager")
+    def test_create_agent_card_with_security_enabled(self, mock_config_manager):
         """Test creating agent card with security enabled."""
-        mock_load_config.return_value = {
+        mock_config = {
             "agent": {"name": "SecureAgent"},
             "skills": [],
             "security": {"enabled": True, "type": "api_key"},
         }
+        mock_config_manager.return_value.config = mock_config
 
         card = create_agent_card()
 
@@ -96,6 +99,38 @@ class TestAgentCard:
         assert card.securitySchemes is not None
         assert card.security is not None
         assert len(card.security) > 0
+
+    @patch("agent.api.routes.ConfigurationManager")
+    def test_create_agent_card_caching(self, mock_config_manager):
+        """Test that agent card is cached properly."""
+        mock_config = {
+            "project_name": "CachedAgent",
+            "agent": {"name": "CachedAgent", "description": "Test caching", "version": "1.0.0"},
+            "plugins": [],
+        }
+        mock_config_manager.return_value.config = mock_config
+
+        # Clear any existing cache
+        import agent.api.routes
+        agent.api.routes._cached_agent_card = None
+        agent.api.routes._cached_extended_agent_card = None
+        agent.api.routes._cached_config_hash = None
+
+        # First call should create the card
+        card1 = create_agent_card()
+        
+        # Second call should return cached version
+        card2 = create_agent_card()
+        
+        # Should be the same instance (cached)
+        assert card1 is card2
+        assert card1.name == "CachedAgent"
+        
+        # Test extended cards are cached separately
+        extended_card1 = create_agent_card(extended=True)
+        extended_card2 = create_agent_card(extended=True)
+        
+        assert extended_card1 is extended_card2
 
 
 class TestRequestHandlerManagement:
@@ -136,10 +171,10 @@ class TestHealthEndpoints:
         """Create test client."""
         return TestClient(app)
 
-    @patch("agent.api.routes.load_config")
-    def test_health_check(self, mock_load_config, client):
+    @patch("agent.api.routes.ConfigurationManager")
+    def test_health_check(self, mock_config_manager, client):
         """Test basic health check endpoint."""
-        mock_load_config.return_value = {"project_name": "TestAgent"}
+        mock_config_manager.return_value.get.return_value = "TestAgent"
 
         response = client.get("/health")
 


### PR DESCRIPTION
Turns out the agentcard was loading every request , discovered while trying to fix rate limiting.  Turns out importing routes also triggers the app module import, which is where the agent card is loaded.

There is an existing existing caching system we can use in ConfigurationManager, so I pair that with a hash capture, so we can hot reload if the config changes. 