### PR TITLE
Improve Python typing and fix Pydantic v2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 
 # AgentUp
 dump.rdb
+.planning/
 
 # Testing and CI artifacts
 .coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,17 @@ src/agent/
 - **Formatting**: Ruff with 120-character line length, double quotes, 4-space indentation
 - **Linting**: Enabled rules include pycodestyle, pyflakes, isort, flake8-bugbear, pyupgrade
 - **Type Hints**: Encouraged but not strictly enforced; MyPy configured for gradual typing
+- **Modern Typing**: Use built-in `dict` and `list` instead of `typing.Dict` and `typing.List` (Python 3.9+)
+- **Pydantic v2**: Use `@field_validator` and `@model_validator` decorators (not deprecated `@validator`)
 - **Naming**: snake_case for functions/variables, PascalCase for classes, UPPER_SNAKE_CASE for constants
 - **Logging**: Use `structlog.get_logger(__name__)` pattern with structured logging
 - **Imports**: Automatic organization via Ruff isort integration
+
+### Typing Guidelines
+- ✅ **Use**: `dict[str, Any]`, `list[str]`, `str | None`
+- ❌ **Avoid**: `Dict[str, Any]`, `List[str]`, `Optional[str]`
+- **Import from typing**: Only `Union`, `Literal`, `Any`, `TypeVar`, `Generic`, `Protocol`
+- **See**: `docs/MODERN_TYPING_GUIDE.md` for complete typing conventions
 
 ## Task Completion Workflow
 

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -4,6 +4,7 @@ Pydantic models for AgentUp configuration.
 This module defines all configuration data structures using Pydantic models
 for type safety and validation.
 """
+
 from __future__ import annotations
 
 import os
@@ -19,6 +20,7 @@ from ..types import ConfigDict, FilePath, LogLevel, ModulePath, ServiceName, Ser
 
 class EnvironmentVariable(BaseModel):
     """Model for environment variable references."""
+
     name: str = Field(..., description="Environment variable name")
     default: str | None = Field(None, description="Default value if not set")
     required: bool = Field(True, description="Whether variable is required")
@@ -34,12 +36,14 @@ class EnvironmentVariable(BaseModel):
 
 class LogFormat(str, Enum):
     """Logging format options."""
+
     TEXT = "text"
     JSON = "json"
 
 
 class LoggingConsoleConfig(BaseModel):
     """Console logging configuration."""
+
     enabled: bool = Field(True, description="Enable console logging")
     colors: bool = Field(True, description="Enable colored output")
     show_time: bool = Field(True, description="Show timestamps")
@@ -48,6 +52,7 @@ class LoggingConsoleConfig(BaseModel):
 
 class LoggingFileConfig(BaseModel):
     """File logging configuration."""
+
     enabled: bool = Field(False, description="Enable file logging")
     path: FilePath = Field("logs/agentup.log", description="Log file path")
     max_size: int = Field(10 * 1024 * 1024, description="Max file size in bytes")
@@ -57,6 +62,7 @@ class LoggingFileConfig(BaseModel):
 
 class LoggingConfig(BaseModel):
     """Comprehensive logging configuration."""
+
     enabled: bool = Field(True, description="Enable logging system")
     level: LogLevel = Field("INFO", description="Global log level")
     format: LogFormat = Field(LogFormat.TEXT, description="Log output format")
@@ -109,6 +115,7 @@ class LoggingConfig(BaseModel):
 
 class ServiceConfig(BaseModel):
     """Base service configuration."""
+
     type: ServiceType = Field(..., description="Service type identifier")
     enabled: bool = Field(True, description="Whether service is enabled")
     init_path: ModulePath | None = Field(None, description="Custom initialization module path")
@@ -142,6 +149,7 @@ class ServiceConfig(BaseModel):
 
 class MCPServerConfig(BaseModel):
     """MCP server configuration."""
+
     name: str = Field(..., description="Server name")
     type: Literal["stdio", "http"] = Field(..., description="Connection type")
 
@@ -157,14 +165,11 @@ class MCPServerConfig(BaseModel):
     timeout: int = Field(30, description="Request timeout in seconds")
 
     # Tool permissions
-    tool_scopes: dict[str, list[str]] = Field(
-        default_factory=dict,
-        description="Tool name to required scopes mapping"
-    )
+    tool_scopes: dict[str, list[str]] = Field(default_factory=dict, description="Tool name to required scopes mapping")
     allowed_tools: list[str] | None = Field(None, description="Allowed tools (None = all)")
     blocked_tools: list[str] = Field(default_factory=list, description="Blocked tools")
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_server_config(self) -> MCPServerConfig:
         """Validate server configuration based on type."""
         if self.type == "stdio":
@@ -180,6 +185,7 @@ class MCPServerConfig(BaseModel):
 
 class MCPConfig(BaseModel):
     """MCP (Model Context Protocol) configuration."""
+
     enabled: bool = Field(False, description="Enable MCP support")
 
     # Client configuration
@@ -206,25 +212,26 @@ class MCPConfig(BaseModel):
 
 class SecurityConfig(BaseModel):
     """Security configuration reference."""
+
     enabled: bool = Field(True, description="Enable security features")
     # Note: Detailed security config is in security/model.py to avoid circular imports
 
 
 class PluginCapabilityConfig(BaseModel):
     """Plugin capability configuration."""
+
     capability_id: str = Field(..., description="Capability identifier")
     name: str | None = Field(None, description="Human-readable name")
     description: str | None = Field(None, description="Capability description")
     required_scopes: list[str] = Field(default_factory=list, description="Required scopes")
     enabled: bool = Field(True, description="Whether capability is enabled")
     config: ConfigDict = Field(default_factory=dict, description="Capability-specific config")
-    middleware_override: list[dict[str, Any]] | None = Field(
-        None, description="Override middleware configuration"
-    )
+    middleware_override: list[dict[str, Any]] | None = Field(None, description="Override middleware configuration")
 
 
 class PluginConfig(BaseModel):
     """Individual plugin configuration."""
+
     plugin_id: str = Field(..., description="Plugin identifier")
     name: str | None = Field(None, description="Plugin name")
     description: str | None = Field(None, description="Plugin description")
@@ -232,9 +239,7 @@ class PluginConfig(BaseModel):
     version: Version | None = Field(None, description="Plugin version constraint")
 
     # Capability configuration
-    capabilities: list[PluginCapabilityConfig] = Field(
-        default_factory=list, description="Plugin capabilities"
-    )
+    capabilities: list[PluginCapabilityConfig] = Field(default_factory=list, description="Plugin capabilities")
 
     # Default settings applied to all capabilities
     default_scopes: list[str] = Field(default_factory=list, description="Default scopes")
@@ -252,11 +257,11 @@ class PluginConfig(BaseModel):
 
 class PluginsConfig(BaseModel):
     """Plugins system configuration."""
+
     enabled: bool = Field(True, description="Enable plugin system")
     auto_discovery: bool = Field(True, description="Enable automatic plugin discovery")
     search_paths: list[FilePath] = Field(
-        default_factory=lambda: ["plugins/", "~/.agentup/plugins/"],
-        description="Plugin search paths"
+        default_factory=lambda: ["plugins/", "~/.agentup/plugins/"], description="Plugin search paths"
     )
 
     # Plugin configurations
@@ -277,40 +282,28 @@ class PluginsConfig(BaseModel):
 
 class MiddlewareConfig(BaseModel):
     """Middleware configuration."""
+
     enabled: bool = Field(True, description="Enable middleware system")
 
     # Rate limiting
     rate_limiting: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "enabled": True,
-            "requests_per_minute": 60,
-            "burst_size": 10
-        }
+        default_factory=lambda: {"enabled": True, "requests_per_minute": 60, "burst_size": 10}
     )
 
     # Caching
     caching: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "enabled": True,
-            "backend": "memory",
-            "default_ttl": 300,
-            "max_size": 1000
-        }
+        default_factory=lambda: {"enabled": True, "backend": "memory", "default_ttl": 300, "max_size": 1000}
     )
 
     # Retry logic
     retry: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "enabled": True,
-            "max_attempts": 3,
-            "initial_delay": 1.0,
-            "max_delay": 60.0
-        }
+        default_factory=lambda: {"enabled": True, "max_attempts": 3, "initial_delay": 1.0, "max_delay": 60.0}
     )
 
 
 class APIConfig(BaseModel):
     """API server configuration."""
+
     enabled: bool = Field(True, description="Enable API server")
     host: str = Field("127.0.0.1", description="Server host")
     port: int = Field(8000, description="Server port")
@@ -329,8 +322,7 @@ class APIConfig(BaseModel):
     cors_enabled: bool = Field(True, description="Enable CORS")
     cors_origins: list[str] = Field(default_factory=lambda: ["*"], description="Allowed origins")
     cors_methods: list[str] = Field(
-        default_factory=lambda: ["GET", "POST", "PUT", "DELETE"],
-        description="Allowed methods"
+        default_factory=lambda: ["GET", "POST", "PUT", "DELETE"], description="Allowed methods"
     )
 
     @field_validator("port")
@@ -352,28 +344,21 @@ class APIConfig(BaseModel):
 
 class AgentConfig(BaseModel):
     """Main agent configuration."""
+
     # Basic agent information
     project_name: str = Field("AgentUp", description="Project name")
     description: str = Field("AI agent powered by AgentUp", description="Agent description")
     version: Version = Field("1.0.0", description="Agent version")
 
     # Module paths for dynamic loading
-    dispatcher_path: ModulePath | None = Field(
-        None, description="Function dispatcher module path"
-    )
+    dispatcher_path: ModulePath | None = Field(None, description="Function dispatcher module path")
     services_enabled: bool = Field(True, description="Enable services system")
-    services_init_path: ModulePath | None = Field(
-        None, description="Services initialization module path"
-    )
+    services_init_path: ModulePath | None = Field(None, description="Services initialization module path")
 
     # MCP integration
     mcp_enabled: bool = Field(False, description="Enable MCP integration")
-    mcp_init_path: ModulePath | None = Field(
-        None, description="MCP initialization module path"
-    )
-    mcp_shutdown_path: ModulePath | None = Field(
-        None, description="MCP shutdown module path"
-    )
+    mcp_init_path: ModulePath | None = Field(None, description="MCP initialization module path")
+    mcp_shutdown_path: ModulePath | None = Field(None, description="MCP shutdown module path")
 
     # Configuration sections
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
@@ -384,9 +369,7 @@ class AgentConfig(BaseModel):
     mcp: MCPConfig = Field(default_factory=MCPConfig)
 
     # Services configuration
-    services: dict[ServiceName, ServiceConfig] = Field(
-        default_factory=dict, description="Service configurations"
-    )
+    services: dict[ServiceName, ServiceConfig] = Field(default_factory=dict, description="Service configurations")
 
     # Custom configuration sections
     custom: ConfigDict = Field(default_factory=dict, description="Custom configuration")
@@ -413,11 +396,12 @@ class AgentConfig(BaseModel):
     def validate_version(cls, v: str) -> str:
         """Validate semantic version format."""
         import re
+
         if not re.match(r"^\d+\.\d+\.\d+(?:-[\w.-]+)?$", v):
             raise ValueError("Version must follow semantic versioning (e.g., 1.0.0)")
         return v
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_mcp_consistency(self) -> AgentConfig:
         """Ensure MCP configuration consistency."""
         if self.mcp_enabled:
@@ -475,7 +459,7 @@ def expand_env_vars(value: Any) -> Any:
 
             return os.getenv(var_name, default or match.group(0))
 
-        return re.sub(r'\$\{([^}]+)\}', replace_env_var, value)
+        return re.sub(r"\$\{([^}]+)\}", replace_env_var, value)
     elif isinstance(value, dict):
         return {k: expand_env_vars(v) for k, v in value.items()}
     elif isinstance(value, list):

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -1,0 +1,501 @@
+"""
+Pydantic models for AgentUp configuration.
+
+This module defines all configuration data structures using Pydantic models
+for type safety and validation.
+"""
+from __future__ import annotations
+
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings
+
+from ..types import ConfigDict, FilePath, LogLevel, ModulePath, ServiceName, ServiceType, Version
+
+
+class EnvironmentVariable(BaseModel):
+    """Model for environment variable references."""
+    name: str = Field(..., description="Environment variable name")
+    default: str | None = Field(None, description="Default value if not set")
+    required: bool = Field(True, description="Whether variable is required")
+
+    @field_validator("name")
+    @classmethod
+    def validate_env_name(cls, v: str) -> str:
+        """Validate environment variable name format."""
+        if not v or not v.replace("_", "").isalnum():
+            raise ValueError("Environment variable name must be alphanumeric with underscores")
+        return v.upper()
+
+
+class LogFormat(str, Enum):
+    """Logging format options."""
+    TEXT = "text"
+    JSON = "json"
+
+
+class LoggingConsoleConfig(BaseModel):
+    """Console logging configuration."""
+    enabled: bool = Field(True, description="Enable console logging")
+    colors: bool = Field(True, description="Enable colored output")
+    show_time: bool = Field(True, description="Show timestamps")
+    show_level: bool = Field(True, description="Show log level")
+
+
+class LoggingFileConfig(BaseModel):
+    """File logging configuration."""
+    enabled: bool = Field(False, description="Enable file logging")
+    path: FilePath = Field("logs/agentup.log", description="Log file path")
+    max_size: int = Field(10 * 1024 * 1024, description="Max file size in bytes")
+    backup_count: int = Field(5, description="Number of backup files to keep")
+    rotation: Literal["size", "time", "never"] = Field("size", description="Rotation strategy")
+
+
+class LoggingConfig(BaseModel):
+    """Comprehensive logging configuration."""
+    enabled: bool = Field(True, description="Enable logging system")
+    level: LogLevel = Field("INFO", description="Global log level")
+    format: LogFormat = Field(LogFormat.TEXT, description="Log output format")
+
+    # Output destinations
+    console: LoggingConsoleConfig = Field(default_factory=LoggingConsoleConfig)
+    file: LoggingFileConfig = Field(default_factory=LoggingFileConfig)
+
+    # Advanced configuration
+    correlation_id: bool = Field(True, description="Include correlation IDs")
+    request_logging: bool = Field(True, description="Log HTTP requests")
+    structured_data: bool = Field(False, description="Include structured metadata")
+
+    # Module-specific log levels
+    modules: dict[str, LogLevel] = Field(default_factory=dict)
+
+    # Third-party integration
+    uvicorn: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "access_log": True,
+            "disable_default_handlers": True,
+            "use_colors": True,
+        }
+    )
+
+    @field_validator("level")
+    @classmethod
+    def validate_log_level(cls, v: str) -> str:
+        """Validate log level values."""
+        valid_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        if isinstance(v, str):
+            v = v.upper()
+            if v not in valid_levels:
+                raise ValueError(f"Invalid log level: {v}. Must be one of {valid_levels}")
+        return v
+
+    @field_validator("modules")
+    @classmethod
+    def validate_module_log_levels(cls, v: dict[str, str]) -> dict[str, str]:
+        """Validate module log level values."""
+        valid_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        for module, level in v.items():
+            if isinstance(level, str):
+                level = level.upper()
+                if level not in valid_levels:
+                    raise ValueError(f"Invalid log level for {module}: {level}. Must be one of {valid_levels}")
+                v[module] = level
+        return v
+
+
+class ServiceConfig(BaseModel):
+    """Base service configuration."""
+    type: ServiceType = Field(..., description="Service type identifier")
+    enabled: bool = Field(True, description="Whether service is enabled")
+    init_path: ModulePath | None = Field(None, description="Custom initialization module path")
+    settings: ConfigDict = Field(default_factory=dict, description="Service-specific settings")
+    priority: int = Field(50, description="Service initialization priority (lower = earlier)")
+
+    # Health check configuration
+    health_check_enabled: bool = Field(True, description="Enable health checks")
+    health_check_interval: int = Field(30, description="Health check interval in seconds")
+
+    # Retry configuration
+    max_retries: int = Field(3, description="Max initialization retries")
+    retry_delay: float = Field(1.0, description="Delay between retries in seconds")
+
+    @field_validator("type")
+    @classmethod
+    def validate_service_type(cls, v: str) -> str:
+        """Validate service type format."""
+        if not v or not v.replace("_", "").replace("-", "").isalnum():
+            raise ValueError("Service type must be alphanumeric with hyphens/underscores")
+        return v.lower()
+
+    @field_validator("priority")
+    @classmethod
+    def validate_priority(cls, v: int) -> int:
+        """Validate priority range."""
+        if not 0 <= v <= 100:
+            raise ValueError("Priority must be between 0 and 100")
+        return v
+
+
+class MCPServerConfig(BaseModel):
+    """MCP server configuration."""
+    name: str = Field(..., description="Server name")
+    type: Literal["stdio", "http"] = Field(..., description="Connection type")
+
+    # For stdio type
+    command: str | None = Field(None, description="Command to run for stdio server")
+    args: list[str] = Field(default_factory=list, description="Command arguments")
+    env: dict[str, str] = Field(default_factory=dict, description="Environment variables")
+    working_dir: FilePath | None = Field(None, description="Working directory")
+
+    # For http type
+    url: str | None = Field(None, description="HTTP server URL")
+    headers: dict[str, str] = Field(default_factory=dict, description="HTTP headers")
+    timeout: int = Field(30, description="Request timeout in seconds")
+
+    # Tool permissions
+    tool_scopes: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Tool name to required scopes mapping"
+    )
+    allowed_tools: list[str] | None = Field(None, description="Allowed tools (None = all)")
+    blocked_tools: list[str] = Field(default_factory=list, description="Blocked tools")
+
+    @model_validator(mode='after')
+    def validate_server_config(self) -> MCPServerConfig:
+        """Validate server configuration based on type."""
+        if self.type == "stdio":
+            if not self.command:
+                raise ValueError("command is required for stdio server")
+        elif self.type == "http":
+            if not self.url:
+                raise ValueError("url is required for http server")
+            if not self.url.startswith(("http://", "https://")):
+                raise ValueError("HTTP server URL must start with http:// or https://")
+        return self
+
+
+class MCPConfig(BaseModel):
+    """MCP (Model Context Protocol) configuration."""
+    enabled: bool = Field(False, description="Enable MCP support")
+
+    # Client configuration
+    client_enabled: bool = Field(True, description="Enable MCP client")
+    client_timeout: int = Field(30, description="Client timeout in seconds")
+    client_retry_attempts: int = Field(3, description="Client retry attempts")
+
+    # Server configuration
+    server_enabled: bool = Field(False, description="Enable MCP server")
+    server_host: str = Field("localhost", description="Server host")
+    server_port: int = Field(8080, description="Server port")
+
+    # Server configurations
+    servers: list[MCPServerConfig] = Field(default_factory=list, description="MCP servers")
+
+    @field_validator("server_port")
+    @classmethod
+    def validate_port(cls, v: int) -> int:
+        """Validate port number."""
+        if not 1 <= v <= 65535:
+            raise ValueError("Port must be between 1 and 65535")
+        return v
+
+
+class SecurityConfig(BaseModel):
+    """Security configuration reference."""
+    enabled: bool = Field(True, description="Enable security features")
+    # Note: Detailed security config is in security/model.py to avoid circular imports
+
+
+class PluginCapabilityConfig(BaseModel):
+    """Plugin capability configuration."""
+    capability_id: str = Field(..., description="Capability identifier")
+    name: str | None = Field(None, description="Human-readable name")
+    description: str | None = Field(None, description="Capability description")
+    required_scopes: list[str] = Field(default_factory=list, description="Required scopes")
+    enabled: bool = Field(True, description="Whether capability is enabled")
+    config: ConfigDict = Field(default_factory=dict, description="Capability-specific config")
+    middleware_override: list[dict[str, Any]] | None = Field(
+        None, description="Override middleware configuration"
+    )
+
+
+class PluginConfig(BaseModel):
+    """Individual plugin configuration."""
+    plugin_id: str = Field(..., description="Plugin identifier")
+    name: str | None = Field(None, description="Plugin name")
+    description: str | None = Field(None, description="Plugin description")
+    enabled: bool = Field(True, description="Whether plugin is enabled")
+    version: Version | None = Field(None, description="Plugin version constraint")
+
+    # Capability configuration
+    capabilities: list[PluginCapabilityConfig] = Field(
+        default_factory=list, description="Plugin capabilities"
+    )
+
+    # Default settings applied to all capabilities
+    default_scopes: list[str] = Field(default_factory=list, description="Default scopes")
+    middleware: list[dict[str, Any]] | None = Field(None, description="Middleware configuration")
+    config: ConfigDict = Field(default_factory=dict, description="Plugin configuration")
+
+    @field_validator("plugin_id")
+    @classmethod
+    def validate_plugin_id(cls, v: str) -> str:
+        """Validate plugin ID format."""
+        if not v or not v.replace("_", "").replace("-", "").replace(".", "").isalnum():
+            raise ValueError("Plugin ID must be alphanumeric with hyphens, underscores, and dots")
+        return v
+
+
+class PluginsConfig(BaseModel):
+    """Plugins system configuration."""
+    enabled: bool = Field(True, description="Enable plugin system")
+    auto_discovery: bool = Field(True, description="Enable automatic plugin discovery")
+    search_paths: list[FilePath] = Field(
+        default_factory=lambda: ["plugins/", "~/.agentup/plugins/"],
+        description="Plugin search paths"
+    )
+
+    # Plugin configurations
+    plugins: list[PluginConfig] = Field(default_factory=list, description="Plugin configurations")
+
+    # Global plugin settings
+    max_plugins: int = Field(100, description="Maximum number of plugins")
+    load_timeout: int = Field(30, description="Plugin load timeout in seconds")
+
+    @field_validator("max_plugins")
+    @classmethod
+    def validate_max_plugins(cls, v: int) -> int:
+        """Validate maximum plugins limit."""
+        if not 1 <= v <= 1000:
+            raise ValueError("max_plugins must be between 1 and 1000")
+        return v
+
+
+class MiddlewareConfig(BaseModel):
+    """Middleware configuration."""
+    enabled: bool = Field(True, description="Enable middleware system")
+
+    # Rate limiting
+    rate_limiting: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "enabled": True,
+            "requests_per_minute": 60,
+            "burst_size": 10
+        }
+    )
+
+    # Caching
+    caching: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "enabled": True,
+            "backend": "memory",
+            "default_ttl": 300,
+            "max_size": 1000
+        }
+    )
+
+    # Retry logic
+    retry: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "enabled": True,
+            "max_attempts": 3,
+            "initial_delay": 1.0,
+            "max_delay": 60.0
+        }
+    )
+
+
+class APIConfig(BaseModel):
+    """API server configuration."""
+    enabled: bool = Field(True, description="Enable API server")
+    host: str = Field("127.0.0.1", description="Server host")
+    port: int = Field(8000, description="Server port")
+
+    # Server settings
+    workers: int = Field(1, description="Number of workers")
+    reload: bool = Field(False, description="Enable auto-reload")
+    debug: bool = Field(False, description="Enable debug mode")
+
+    # Request handling
+    max_request_size: int = Field(16 * 1024 * 1024, description="Max request size in bytes")
+    request_timeout: int = Field(30, description="Request timeout in seconds")
+    keepalive_timeout: int = Field(5, description="Keep-alive timeout in seconds")
+
+    # CORS settings
+    cors_enabled: bool = Field(True, description="Enable CORS")
+    cors_origins: list[str] = Field(default_factory=lambda: ["*"], description="Allowed origins")
+    cors_methods: list[str] = Field(
+        default_factory=lambda: ["GET", "POST", "PUT", "DELETE"],
+        description="Allowed methods"
+    )
+
+    @field_validator("port")
+    @classmethod
+    def validate_port(cls, v: int) -> int:
+        """Validate port number."""
+        if not 1 <= v <= 65535:
+            raise ValueError("Port must be between 1 and 65535")
+        return v
+
+    @field_validator("workers")
+    @classmethod
+    def validate_workers(cls, v: int) -> int:
+        """Validate worker count."""
+        if not 1 <= v <= 32:
+            raise ValueError("Workers must be between 1 and 32")
+        return v
+
+
+class AgentConfig(BaseModel):
+    """Main agent configuration."""
+    # Basic agent information
+    project_name: str = Field("AgentUp", description="Project name")
+    description: str = Field("AI agent powered by AgentUp", description="Agent description")
+    version: Version = Field("1.0.0", description="Agent version")
+
+    # Module paths for dynamic loading
+    dispatcher_path: ModulePath | None = Field(
+        None, description="Function dispatcher module path"
+    )
+    services_enabled: bool = Field(True, description="Enable services system")
+    services_init_path: ModulePath | None = Field(
+        None, description="Services initialization module path"
+    )
+
+    # MCP integration
+    mcp_enabled: bool = Field(False, description="Enable MCP integration")
+    mcp_init_path: ModulePath | None = Field(
+        None, description="MCP initialization module path"
+    )
+    mcp_shutdown_path: ModulePath | None = Field(
+        None, description="MCP shutdown module path"
+    )
+
+    # Configuration sections
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    api: APIConfig = Field(default_factory=APIConfig)
+    security: SecurityConfig = Field(default_factory=SecurityConfig)
+    plugins: PluginsConfig = Field(default_factory=PluginsConfig)
+    middleware: MiddlewareConfig = Field(default_factory=MiddlewareConfig)
+    mcp: MCPConfig = Field(default_factory=MCPConfig)
+
+    # Services configuration
+    services: dict[ServiceName, ServiceConfig] = Field(
+        default_factory=dict, description="Service configurations"
+    )
+
+    # Custom configuration sections
+    custom: ConfigDict = Field(default_factory=dict, description="Custom configuration")
+
+    # Environment-specific settings
+    environment: Literal["development", "staging", "production"] = Field(
+        "development", description="Deployment environment"
+    )
+
+    class Config:
+        extra = "forbid"  # Prevent unknown configuration fields
+        validate_assignment = True
+
+    @field_validator("project_name")
+    @classmethod
+    def validate_project_name(cls, v: str) -> str:
+        """Validate project name format."""
+        if not v or len(v) > 100:
+            raise ValueError("Project name must be 1-100 characters")
+        return v
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, v: str) -> str:
+        """Validate semantic version format."""
+        import re
+        if not re.match(r"^\d+\.\d+\.\d+(?:-[\w.-]+)?$", v):
+            raise ValueError("Version must follow semantic versioning (e.g., 1.0.0)")
+        return v
+
+    @model_validator(mode='after')
+    def validate_mcp_consistency(self) -> AgentConfig:
+        """Ensure MCP configuration consistency."""
+        if self.mcp_enabled:
+            if not self.mcp.enabled:
+                self.mcp = MCPConfig(enabled=True)
+        return self
+
+
+class ConfigurationSettings(BaseSettings):
+    """Environment-based configuration settings."""
+
+    # File paths
+    CONFIG_FILE: FilePath = Field("agentup.yml", description="Main configuration file")
+    CONFIG_DIR: FilePath = Field(".", description="Configuration directory")
+    DATA_DIR: FilePath = Field("data/", description="Data directory")
+    LOGS_DIR: FilePath = Field("logs/", description="Logs directory")
+    PLUGINS_DIR: FilePath = Field("plugins/", description="Plugins directory")
+
+    # Environment overrides
+    ENVIRONMENT: str = Field("development", description="Deployment environment")
+    DEBUG: bool = Field(False, description="Debug mode")
+    LOG_LEVEL: LogLevel = Field("INFO", description="Global log level")
+
+    # API settings
+    API_HOST: str = Field("127.0.0.1", description="API server host")
+    API_PORT: int = Field(8000, description="API server port")
+
+    # Security settings
+    SECRET_KEY: str | None = Field(None, description="Application secret key")
+
+    class Config:
+        env_prefix = "AGENTUP_"
+        case_sensitive = True
+
+    def create_directories(self) -> None:
+        """Create necessary directories if they don't exist."""
+        directories = [self.DATA_DIR, self.LOGS_DIR, self.PLUGINS_DIR]
+        for directory in directories:
+            Path(directory).mkdir(parents=True, exist_ok=True)
+
+
+# Utility function for environment variable expansion
+def expand_env_vars(value: Any) -> Any:
+    """Expand environment variables in configuration values."""
+    if isinstance(value, str):
+        # Handle ${VAR} and ${VAR:default} patterns
+        import re
+
+        def replace_env_var(match):
+            var_spec = match.group(1)
+            if ":" in var_spec:
+                var_name, default = var_spec.split(":", 1)
+            else:
+                var_name, default = var_spec, None
+
+            return os.getenv(var_name, default or match.group(0))
+
+        return re.sub(r'\$\{([^}]+)\}', replace_env_var, value)
+    elif isinstance(value, dict):
+        return {k: expand_env_vars(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [expand_env_vars(item) for item in value]
+
+    return value
+
+
+# Re-export key models
+__all__ = [
+    "AgentConfig",
+    "ServiceConfig",
+    "LoggingConfig",
+    "APIConfig",
+    "SecurityConfig",
+    "PluginsConfig",
+    "PluginConfig",
+    "MiddlewareConfig",
+    "MCPConfig",
+    "ConfigurationSettings",
+    "EnvironmentVariable",
+    "expand_env_vars",
+]

--- a/src/agent/config/models.py
+++ b/src/agent/config/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Import typing for exception classes
 from abc import ABC
 from typing import Any
@@ -89,7 +91,7 @@ class PluginsConfig(BaseModel):
     plugins: list[PluginConfig] = []
 
     @classmethod
-    def from_config_value(cls, config_value) -> "PluginsConfig":
+    def from_config_value(cls, config_value) -> PluginsConfig:
         """Create PluginsConfig from various config formats."""
         if isinstance(config_value, dict):
             if "enabled" in config_value or "plugins" in config_value:

--- a/src/agent/security/model.py
+++ b/src/agent/security/model.py
@@ -1,0 +1,575 @@
+"""
+Pydantic models for AgentUp security module.
+
+This module defines all security-related data structures including authentication,
+authorization, and audit logging models.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
+
+from agent.types import (
+    CookieName,
+    HeaderName,
+    IPAddress,
+    JsonValue,
+    QueryParam,
+    ScopeName,
+    Timestamp,
+    UserId,
+)
+
+
+class AuthType(str, Enum):
+    """Supported authentication types."""
+    API_KEY = "api_key"
+    BEARER = "bearer"
+    JWT = "jwt"
+    OAUTH2 = "oauth2"
+
+
+class Scope(BaseModel):
+    """Security scope definition with hierarchy support."""
+    name: ScopeName = Field(..., description="Scope name")
+    description: str | None = Field(None, description="Scope description")
+    parent: ScopeName | None = Field(None, description="Parent scope name")
+
+    @field_validator("name")
+    @classmethod
+    def validate_scope_format(cls, v: str) -> str:
+        """Ensure scope follows naming convention."""
+        import re
+        # Scopes should be lowercase with colons for hierarchy
+        # e.g., "read", "write", "admin:users", "api:v1:read"
+        if not re.match(r"^[a-z0-9]+(?::[a-z0-9]+)*$", v):
+            raise ValueError(
+                f"Invalid scope format: {v}. "
+                "Use lowercase alphanumeric with colons for hierarchy"
+            )
+        return v
+
+    def is_subscope_of(self, parent: Scope) -> bool:
+        """Check if this scope is a subscope of parent."""
+        return self.name.startswith(f"{parent.name}:")
+
+    def __hash__(self) -> int:
+        """Make Scope hashable for use in sets."""
+        return hash(self.name)
+
+    def __eq__(self, other) -> bool:
+        """Compare scopes by name."""
+        if isinstance(other, Scope):
+            return self.name == other.name
+        return False
+
+    class Config:
+        frozen = True  # Scopes are immutable
+
+
+class APIKeyData(BaseModel):
+    """API key with metadata and permissions."""
+    key: SecretStr = Field(..., description="The API key value")
+    name: str | None = Field(None, description="Human-readable key name")
+    scopes: list[Scope] = Field(default_factory=list, description="Assigned scopes")
+    description: str | None = Field(None, description="Key description")
+    created_at: Timestamp = Field(default_factory=datetime.utcnow, description="Creation time")
+    expires_at: Timestamp | None = Field(None, description="Expiration time")
+    last_used: Timestamp | None = Field(None, description="Last usage time")
+    usage_count: int = Field(0, description="Usage counter")
+
+    @field_validator("key")
+    @classmethod
+    def validate_key_strength(cls, v: SecretStr) -> SecretStr:
+        """Ensure API key meets security requirements."""
+        key_str = v.get_secret_value()
+
+        # Skip validation for env var placeholders
+        if key_str.startswith("${") and key_str.endswith("}"):
+            return v
+
+        if len(key_str) < 32:
+            raise ValueError("API key must be at least 32 characters")
+        if len(key_str) > 128:
+            raise ValueError("API key must be no more than 128 characters")
+
+        # Check entropy (simplified)
+        import string
+        char_types = 0
+        if any(c in string.ascii_lowercase for c in key_str):
+            char_types += 1
+        if any(c in string.ascii_uppercase for c in key_str):
+            char_types += 1
+        if any(c in string.digits for c in key_str):
+            char_types += 1
+        if any(c in string.punctuation for c in key_str):
+            char_types += 1
+
+        if char_types < 3:
+            raise ValueError(
+                "API key must contain at least 3 different character types "
+                "(lowercase, uppercase, digits, special)"
+            )
+
+        return v
+
+    @model_validator(mode='after')
+    def validate_expiration(self) -> APIKeyData:
+        """Ensure expiration is in the future."""
+        if self.expires_at and self.created_at:
+            if self.expires_at <= self.created_at:
+                raise ValueError("Expiration must be after creation time")
+        return self
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the key has expired."""
+        if not self.expires_at:
+            return False
+        return datetime.utcnow() > self.expires_at
+
+    def has_scope(self, scope: str | Scope) -> bool:
+        """Check if key has a specific scope or any parent scope."""
+        if isinstance(scope, str):
+            scope = Scope(name=scope)
+
+        for key_scope in self.scopes:
+            if key_scope.name == scope.name:
+                return True
+            # Check if key has a parent scope
+            if scope.is_subscope_of(key_scope):
+                return True
+        return False
+
+
+class APIKeyConfig(BaseModel):
+    """API key authentication configuration."""
+    header_name: HeaderName = Field(
+        "X-API-Key",
+        description="HTTP header name for API key"
+    )
+    location: Literal["header", "query", "cookie"] = Field(
+        "header",
+        description="Where to look for the API key"
+    )
+    query_param: QueryParam = Field(
+        "api_key",
+        description="Query parameter name if location is 'query'"
+    )
+    cookie_name: CookieName = Field(
+        "api_key",
+        description="Cookie name if location is 'cookie'"
+    )
+    keys: list[APIKeyData] = Field(
+        ...,
+        min_items=1,
+        description="List of valid API keys"
+    )
+
+    @field_validator("header_name")
+    @classmethod
+    def validate_header_name(cls, v: str) -> str:
+        """Validate HTTP header name format."""
+        import re
+        if not re.match(r"^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$", v):
+            raise ValueError(f"Invalid header name format: {v}")
+        return v
+
+    @field_validator("keys")
+    @classmethod
+    def validate_unique_keys(cls, v: list[APIKeyData]) -> list[APIKeyData]:
+        """Ensure all API keys are unique."""
+        seen = set()
+        for key_data in v:
+            key_value = key_data.key.get_secret_value()
+            if key_value in seen:
+                raise ValueError("Duplicate API keys are not allowed")
+            seen.add(key_value)
+        return v
+
+
+class JWTAlgorithm(str, Enum):
+    """Supported JWT algorithms."""
+    HS256 = "HS256"
+    HS384 = "HS384"
+    HS512 = "HS512"
+    RS256 = "RS256"
+    RS384 = "RS384"
+    RS512 = "RS512"
+    ES256 = "ES256"
+    ES384 = "ES384"
+    ES512 = "ES512"
+
+
+class JWTConfig(BaseModel):
+    """JWT authentication configuration."""
+    secret_key: SecretStr = Field(..., description="JWT signing key")
+    algorithm: JWTAlgorithm = Field(
+        JWTAlgorithm.HS256,
+        description="JWT signing algorithm"
+    )
+    expiration: timedelta = Field(
+        timedelta(hours=1),
+        description="Token expiration time"
+    )
+    issuer: str | None = Field(None, description="Expected token issuer")
+    audience: str | None = Field(None, description="Expected token audience")
+
+    # Public key for RS/ES algorithms
+    public_key: SecretStr | None = Field(
+        None,
+        description="Public key for asymmetric algorithms"
+    )
+
+    # Token claims
+    required_claims: list[str] = Field(
+        default_factory=lambda: ["sub", "exp"],
+        description="Claims that must be present"
+    )
+
+    @model_validator(mode='after')
+    def validate_algorithm_key_pair(self) -> JWTConfig:
+        """Ensure proper keys for algorithm type."""
+        if self.algorithm in [JWTAlgorithm.RS256, JWTAlgorithm.RS384, JWTAlgorithm.RS512,
+                              JWTAlgorithm.ES256, JWTAlgorithm.ES384, JWTAlgorithm.ES512]:
+            if not self.public_key:
+                raise ValueError(
+                    f"Public key required for {self.algorithm} algorithm"
+                )
+        return self
+
+
+class OAuth2Config(BaseModel):
+    """OAuth2 authentication configuration."""
+    client_id: str = Field(..., description="OAuth2 client ID")
+    client_secret: SecretStr = Field(..., description="OAuth2 client secret")
+    authorization_url: str = Field(..., description="Authorization endpoint URL")
+    token_url: str = Field(..., description="Token endpoint URL")
+    redirect_uri: str = Field(..., description="Redirect URI")
+    scopes: list[str] = Field(default_factory=list, description="OAuth2 scopes")
+
+    # Token validation strategy
+    validation_strategy: Literal["jwt", "introspection", "both"] = Field(
+        "jwt", description="Token validation method"
+    )
+
+    # JWT validation settings
+    jwks_url: str | None = Field(None, description="JWKS endpoint URL")
+    jwt_algorithm: JWTAlgorithm = Field(
+        JWTAlgorithm.RS256, description="JWT algorithm for validation"
+    )
+    jwt_audience: str | None = Field(None, description="Expected JWT audience")
+    jwt_issuer: str | None = Field(None, description="Expected JWT issuer")
+
+    # Introspection settings
+    introspection_endpoint: str | None = Field(None, description="Token introspection endpoint")
+    introspection_auth_method: Literal["client_secret_basic", "client_secret_post"] = Field(
+        "client_secret_basic", description="Introspection authentication method"
+    )
+
+    # Advanced settings
+    use_pkce: bool = Field(True, description="Use PKCE for authorization code flow")
+    token_endpoint_auth_method: str = Field(
+        "client_secret_basic", description="Token endpoint authentication method"
+    )
+
+    @field_validator("authorization_url", "token_url", "jwks_url", "introspection_endpoint")
+    @classmethod
+    def validate_urls(cls, v: str | None) -> str | None:
+        """Validate URL format."""
+        if v and not v.startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL: {v}")
+        return v
+
+    @model_validator(mode='after')
+    def validate_strategy_config(self) -> OAuth2Config:
+        """Ensure required fields for validation strategy."""
+        if self.validation_strategy in ["jwt", "both"] and not self.jwks_url:
+            raise ValueError("jwks_url required for JWT validation")
+        if self.validation_strategy in ["introspection", "both"] and not self.introspection_endpoint:
+            raise ValueError("introspection_endpoint required for introspection")
+        return self
+
+
+class SecurityConfig(BaseModel):
+    """Complete security configuration."""
+    enabled: bool = Field(True, description="Enable security features")
+
+    # Authentication methods (at least one required)
+    auth: dict[AuthType, APIKeyConfig | JWTConfig | OAuth2Config] = Field(
+        ...,
+        description="Authentication configurations by type"
+    )
+
+    # Global security settings
+    require_https: bool = Field(
+        True,
+        description="Require HTTPS for all requests"
+    )
+    allowed_origins: list[str] = Field(
+        default_factory=lambda: ["*"],
+        description="CORS allowed origins"
+    )
+    allowed_methods: list[str] = Field(
+        default_factory=lambda: ["GET", "POST", "PUT", "DELETE"],
+        description="Allowed HTTP methods"
+    )
+
+    # Security headers
+    enable_hsts: bool = Field(True, description="Enable HSTS header")
+    enable_csrf: bool = Field(True, description="Enable CSRF protection")
+
+    # Audit logging
+    audit_logging: bool = Field(True, description="Enable audit logging")
+    audit_log_retention_days: int = Field(90, ge=1, le=365, description="Audit log retention")
+
+    # Rate limiting
+    enable_rate_limiting: bool = Field(True, description="Enable rate limiting")
+    rate_limit_requests: int = Field(60, description="Requests per minute")
+
+    @field_validator("auth")
+    @classmethod
+    def validate_auth_config(cls, v: dict) -> dict:
+        """Ensure at least one auth method is configured."""
+        if not v:
+            raise ValueError("At least one authentication method must be configured")
+
+        # Validate auth type matches config type
+        for auth_type, config in v.items():
+            expected_type = {
+                AuthType.API_KEY: APIKeyConfig,
+                AuthType.JWT: JWTConfig,
+                AuthType.OAUTH2: OAuth2Config,
+                AuthType.BEARER: JWTConfig,  # Bearer uses JWT config
+            }
+
+            if auth_type in expected_type:
+                if not isinstance(config, expected_type[auth_type]):
+                    raise ValueError(
+                        f"Invalid config type for {auth_type}. "
+                        f"Expected {expected_type[auth_type].__name__}"
+                    )
+
+        return v
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def validate_origins(cls, v: list[str]) -> list[str]:
+        """Validate CORS origins."""
+        for origin in v:
+            if origin != "*" and not origin.startswith(("http://", "https://")):
+                raise ValueError(f"Invalid origin: {origin}")
+        return v
+
+
+class AuthResult(str, Enum):
+    """Authentication result status."""
+    SUCCESS = "success"
+    INVALID_CREDENTIALS = "invalid_credentials"
+    EXPIRED = "expired"
+    INSUFFICIENT_SCOPE = "insufficient_scope"
+    DISABLED = "disabled"
+    ERROR = "error"
+
+
+class AuthContext(BaseModel):
+    """Runtime authentication context."""
+    authenticated: bool = Field(False, description="Whether request is authenticated")
+    auth_type: AuthType | None = Field(None, description="Type of authentication used")
+    auth_result: AuthResult | None = Field(None, description="Authentication result")
+
+    # User information
+    user_id: UserId | None = Field(None, description="User identifier")
+    username: str | None = Field(None, description="Username")
+    email: str | None = Field(None, description="User email")
+
+    # Permissions
+    scopes: set[Scope] = Field(default_factory=set, description="User scopes")
+    roles: set[str] = Field(default_factory=set, description="User roles")
+
+    # Request metadata
+    ip_address: IPAddress | None = Field(None, description="Client IP address")
+    user_agent: str | None = Field(None, description="User agent string")
+    request_id: str | None = Field(None, description="Request identifier")
+
+    # Token/Key metadata
+    token_id: str | None = Field(None, description="Token identifier")
+    key_name: str | None = Field(None, description="API key name")
+    expires_at: Timestamp | None = Field(None, description="Token expiration")
+
+    # Additional context
+    metadata: dict[str, str] = Field(default_factory=dict, description="Additional metadata")
+
+    def has_scope(self, scope: str | Scope) -> bool:
+        """Check if context has a specific scope."""
+        if isinstance(scope, str):
+            scope = Scope(name=scope)
+
+        for ctx_scope in self.scopes:
+            if ctx_scope.name == scope.name:
+                return True
+            if scope.is_subscope_of(ctx_scope):
+                return True
+        return False
+
+    def has_any_scope(self, scopes: list[str | Scope]) -> bool:
+        """Check if context has any of the specified scopes."""
+        return any(self.has_scope(scope) for scope in scopes)
+
+    def has_all_scopes(self, scopes: list[str | Scope]) -> bool:
+        """Check if context has all specified scopes."""
+        return all(self.has_scope(scope) for scope in scopes)
+
+    class Config:
+        # Allow set type for scopes
+        arbitrary_types_allowed = True
+
+
+class AuditAction(str, Enum):
+    """Types of auditable actions."""
+    LOGIN = "login"
+    LOGOUT = "logout"
+    CREATE = "create"
+    READ = "read"
+    UPDATE = "update"
+    DELETE = "delete"
+    EXECUTE = "execute"
+    GRANT = "grant"
+    REVOKE = "revoke"
+    EXPORT = "export"
+    IMPORT = "import"
+
+
+class AuditResult(str, Enum):
+    """Result of an audited action."""
+    SUCCESS = "success"
+    FAILURE = "failure"
+    ERROR = "error"
+    BLOCKED = "blocked"
+
+
+class AuditLogEntry(BaseModel):
+    """Security audit log entry with comprehensive tracking."""
+    # Timing
+    timestamp: Timestamp = Field(default_factory=datetime.utcnow, description="Event timestamp")
+    duration_ms: float | None = Field(None, description="Operation duration in milliseconds")
+
+    # Event information
+    event_type: str = Field(..., description="Type of event (e.g., 'auth', 'access')")
+    action: AuditAction = Field(..., description="Action performed")
+    result: AuditResult = Field(..., description="Action result")
+
+    # Actor information
+    user_id: UserId | None = Field(None, description="User identifier")
+    username: str | None = Field(None, description="Username")
+    auth_type: AuthType | None = Field(None, description="Authentication type used")
+
+    # Resource information
+    resource_type: str | None = Field(None, description="Type of resource accessed")
+    resource_id: str | None = Field(None, description="Resource identifier")
+    resource_name: str | None = Field(None, description="Resource name")
+
+    # Request context
+    ip_address: IPAddress | None = Field(None, description="Client IP address")
+    user_agent: str | None = Field(None, description="User agent string")
+    request_id: str | None = Field(None, description="Request identifier")
+    session_id: str | None = Field(None, description="Session identifier")
+
+    # Details
+    details: dict[str, str] = Field(default_factory=dict, description="Additional details")
+    error_message: str | None = Field(None, description="Error message if applicable")
+
+    # Compliance fields
+    data_classification: str | None = Field(None, description="Data classification level")
+    compliance_tags: list[str] = Field(default_factory=list, description="Compliance tags")
+
+    def to_log_format(self) -> str:
+        """Format entry for logging."""
+        parts = [
+            f"[{self.timestamp.isoformat()}]",
+            f"EVENT={self.event_type}",
+            f"ACTION={self.action.value}",
+            f"RESULT={self.result.value}",
+        ]
+
+        if self.user_id:
+            parts.append(f"USER={self.user_id}")
+        if self.resource_type and self.resource_id:
+            parts.append(f"RESOURCE={self.resource_type}:{self.resource_id}")
+        if self.ip_address:
+            parts.append(f"IP={self.ip_address}")
+        if self.error_message:
+            parts.append(f"ERROR={self.error_message}")
+
+        return " ".join(parts)
+
+    class Config:
+        # Allow JSON serialization of datetime
+        json_encoders = {
+            datetime: lambda v: v.isoformat()
+        }
+
+
+class PermissionCheck(BaseModel):
+    """Request for permission verification."""
+    user_id: UserId = Field(..., description="User to check")
+    resource_type: str = Field(..., description="Resource type")
+    resource_id: str | None = Field(None, description="Specific resource ID")
+    action: str = Field(..., description="Action to perform")
+    context: dict[str, JsonValue] = Field(default_factory=dict, description="Additional context")
+
+
+class PermissionResult(BaseModel):
+    """Result of permission check."""
+    granted: bool = Field(..., description="Whether permission is granted")
+    reason: str | None = Field(None, description="Reason for denial")
+    required_scopes: list[str] = Field(default_factory=list, description="Required scopes")
+    missing_scopes: list[str] = Field(default_factory=list, description="Missing scopes")
+    conditions: list[str] = Field(default_factory=list, description="Additional conditions")
+
+
+class SecurityEvent(BaseModel):
+    """Security event for monitoring and alerting."""
+    event_id: str = Field(..., description="Unique event identifier")
+    timestamp: Timestamp = Field(default_factory=datetime.utcnow, description="Event timestamp")
+    severity: Literal["low", "medium", "high", "critical"] = Field(..., description="Event severity")
+    category: str = Field(..., description="Event category")
+    title: str = Field(..., description="Event title")
+    description: str = Field(..., description="Event description")
+
+    # Context
+    user_id: UserId | None = Field(None, description="Associated user")
+    ip_address: IPAddress | None = Field(None, description="Source IP")
+    user_agent: str | None = Field(None, description="User agent")
+
+    # Metadata
+    tags: list[str] = Field(default_factory=list, description="Event tags")
+    metadata: dict[str, JsonValue] = Field(default_factory=dict, description="Additional metadata")
+
+    # Alerting
+    alert_sent: bool = Field(False, description="Whether alert was sent")
+    alert_recipients: list[str] = Field(default_factory=list, description="Alert recipients")
+
+
+# Re-export commonly used models
+__all__ = [
+    "AuthType",
+    "Scope",
+    "APIKeyData",
+    "APIKeyConfig",
+    "JWTConfig",
+    "JWTAlgorithm",
+    "OAuth2Config",
+    "SecurityConfig",
+    "AuthResult",
+    "AuthContext",
+    "AuditAction",
+    "AuditResult",
+    "AuditLogEntry",
+    "PermissionCheck",
+    "PermissionResult",
+    "SecurityEvent",
+]

--- a/src/agent/state/context.py
+++ b/src/agent/state/context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 from dataclasses import dataclass
@@ -34,7 +36,7 @@ class ConversationState:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ConversationState":
+    def from_dict(cls, data: dict[str, Any]) -> ConversationState:
         """Create from dictionary."""
         return cls(
             context_id=data["context_id"],

--- a/src/agent/state/model.py
+++ b/src/agent/state/model.py
@@ -1,0 +1,499 @@
+"""
+Pydantic models for AgentUp state management.
+
+This module defines all state-related data structures including conversation state,
+variables, and backend configuration.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Generic, Literal, TypeVar
+
+from pydantic import BaseModel, Field, field_validator
+
+from ..types import TTL, ConfigDict, FilePath, SessionId, Timestamp, UserId
+
+# Generic type for state variables
+T = TypeVar('T')
+
+
+class StateVariableType(str, Enum):
+    """Types of state variables."""
+    STRING = "string"
+    INTEGER = "integer"
+    FLOAT = "float"
+    BOOLEAN = "boolean"
+    LIST = "list"
+    DICT = "dict"
+    JSON = "json"
+    BINARY = "binary"
+
+
+class StateVariable(BaseModel, Generic[T]):
+    """Typed state variable with metadata."""
+    key: str = Field(..., description="Variable key")
+    value: T = Field(..., description="Variable value")
+    type_name: StateVariableType = Field(..., description="Variable type")
+    created_at: Timestamp = Field(default_factory=datetime.utcnow, description="Creation time")
+    updated_at: Timestamp = Field(default_factory=datetime.utcnow, description="Last update time")
+    ttl: TTL | None = Field(None, description="Time-to-live in seconds")
+    version: int = Field(1, description="Variable version for optimistic locking")
+
+    # Metadata
+    description: str | None = Field(None, description="Variable description")
+    tags: list[str] = Field(default_factory=list, description="Variable tags")
+    metadata: dict[str, str] = Field(default_factory=dict, description="Additional metadata")
+
+    @field_validator("key")
+    @classmethod
+    def validate_key(cls, v: str) -> str:
+        """Validate variable key format."""
+        if not v or len(v) > 256:
+            raise ValueError("Key must be 1-256 characters")
+        # Allow alphanumeric, dots, hyphens, underscores
+        import re
+        if not re.match(r"^[a-zA-Z0-9._-]+$", v):
+            raise ValueError("Key can only contain alphanumeric characters, dots, hyphens, and underscores")
+        return v
+
+    @field_validator("ttl")
+    @classmethod
+    def validate_ttl(cls, v: TTL | None) -> TTL | None:
+        """Validate TTL value."""
+        if v is not None and v <= 0:
+            raise ValueError("TTL must be positive")
+        return v
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if variable has expired."""
+        if not self.ttl:
+            return False
+        expires_at = self.updated_at + timedelta(seconds=self.ttl)
+        return datetime.utcnow() > expires_at
+
+    def touch(self) -> None:
+        """Update the last modified timestamp."""
+        self.updated_at = datetime.utcnow()
+        self.version += 1
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ConversationRole(str, Enum):
+    """Roles in a conversation."""
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    FUNCTION = "function"
+    TOOL = "tool"
+
+
+class ConversationMessage(BaseModel):
+    """Single message in conversation history."""
+    id: str = Field(..., description="Message identifier")
+    role: ConversationRole = Field(..., description="Message role")
+    content: str = Field(..., description="Message content")
+    timestamp: Timestamp = Field(default_factory=datetime.utcnow, description="Message timestamp")
+
+    # Message metadata
+    metadata: dict[str, str] = Field(default_factory=dict, description="Message metadata")
+    tokens: int | None = Field(None, description="Token count")
+
+    # Function/tool calling
+    function_name: str | None = Field(None, description="Function name if role is function")
+    function_call: dict[str, Any] | None = Field(None, description="Function call data")
+    tool_calls: list[dict[str, Any]] = Field(default_factory=list, description="Tool calls")
+
+    # Message relationships
+    reply_to: str | None = Field(None, description="ID of message this replies to")
+    thread_id: str | None = Field(None, description="Thread identifier")
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: str) -> str:
+        """Validate message content."""
+        if len(v) > 1_000_000:  # 1MB limit
+            raise ValueError("Message content too large (max 1MB)")
+        return v
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, v: str) -> str:
+        """Validate message ID format."""
+        if not v or len(v) > 128:
+            raise ValueError("Message ID must be 1-128 characters")
+        return v
+
+
+class ConversationSummary(BaseModel):
+    """Summary of conversation history."""
+    total_messages: int = Field(..., description="Total number of messages")
+    user_messages: int = Field(..., description="Number of user messages")
+    assistant_messages: int = Field(..., description="Number of assistant messages")
+    total_tokens: int | None = Field(None, description="Total token count")
+    first_message_at: Timestamp | None = Field(None, description="First message timestamp")
+    last_message_at: Timestamp | None = Field(None, description="Last message timestamp")
+    topics: list[str] = Field(default_factory=list, description="Conversation topics")
+    summary_text: str | None = Field(None, description="Human-readable summary")
+
+
+class ConversationState(BaseModel):
+    """Complete conversation state management."""
+    context_id: str = Field(..., description="Conversation context identifier")
+    user_id: UserId | None = Field(None, description="Associated user")
+    session_id: SessionId | None = Field(None, description="Session identifier")
+
+    # Timestamps
+    created_at: Timestamp = Field(default_factory=datetime.utcnow, description="Creation time")
+    updated_at: Timestamp = Field(default_factory=datetime.utcnow, description="Last update time")
+    last_activity: Timestamp = Field(default_factory=datetime.utcnow, description="Last activity time")
+
+    # State data
+    variables: dict[str, StateVariable] = Field(
+        default_factory=dict, description="State variables"
+    )
+    metadata: dict[str, str] = Field(default_factory=dict, description="Conversation metadata")
+    history: list[ConversationMessage] = Field(
+        default_factory=list, description="Message history"
+    )
+
+    # Configuration
+    max_history_size: int = Field(100, description="Maximum history size")
+    max_variable_count: int = Field(1000, description="Maximum variable count")
+    auto_summarize: bool = Field(True, description="Auto-summarize old messages")
+
+    # Summary and archival
+    summary: ConversationSummary | None = Field(None, description="Conversation summary")
+    archived_messages: int = Field(0, description="Number of archived messages")
+
+    # Tags and categorization
+    tags: list[str] = Field(default_factory=list, description="Conversation tags")
+    category: str | None = Field(None, description="Conversation category")
+    priority: int = Field(0, description="Conversation priority")
+
+    @field_validator("context_id")
+    @classmethod
+    def validate_context_id(cls, v: str) -> str:
+        """Validate context ID format."""
+        if not v or len(v) > 128:
+            raise ValueError("Context ID must be 1-128 characters")
+        return v
+
+    @field_validator("max_history_size", "max_variable_count")
+    @classmethod
+    def validate_limits(cls, v: int) -> int:
+        """Validate size limits."""
+        if v <= 0:
+            raise ValueError("Limits must be positive")
+        if v > 10000:
+            raise ValueError("Limits too large (max 10000)")
+        return v
+
+    def add_message(self, message: ConversationMessage) -> None:
+        """Add message with size limit enforcement."""
+        self.history.append(message)
+        self.last_activity = datetime.utcnow()
+        self.updated_at = self.last_activity
+
+        # Enforce history size limit
+        if len(self.history) > self.max_history_size:
+            if self.auto_summarize:
+                self._archive_old_messages()
+            else:
+                # Remove oldest messages
+                removed = self.history[:-self.max_history_size]
+                self.history = self.history[-self.max_history_size:]
+                self.archived_messages += len(removed)
+
+    def set_variable(self, key: str, value: Any, ttl: TTL | None = None) -> None:
+        """Set a state variable."""
+        if len(self.variables) >= self.max_variable_count and key not in self.variables:
+            raise ValueError(f"Maximum variable count ({self.max_variable_count}) exceeded")
+
+        # Determine type
+        var_type = self._determine_type(value)
+
+        if key in self.variables:
+            # Update existing variable
+            var = self.variables[key]
+            var.value = value
+            var.touch()
+            if ttl is not None:
+                var.ttl = ttl
+        else:
+            # Create new variable
+            self.variables[key] = StateVariable(
+                key=key,
+                value=value,
+                type_name=var_type,
+                ttl=ttl
+            )
+
+        self.updated_at = datetime.utcnow()
+
+    def get_variable(self, key: str, default: Any = None) -> Any:
+        """Get a state variable value."""
+        if key not in self.variables:
+            return default
+
+        var = self.variables[key]
+        if var.is_expired:
+            del self.variables[key]
+            return default
+
+        return var.value
+
+    def delete_variable(self, key: str) -> bool:
+        """Delete a state variable."""
+        if key in self.variables:
+            del self.variables[key]
+            self.updated_at = datetime.utcnow()
+            return True
+        return False
+
+    def cleanup_expired_variables(self) -> int:
+        """Remove expired variables and return count removed."""
+        expired_keys = [
+            key for key, var in self.variables.items()
+            if var.is_expired
+        ]
+
+        for key in expired_keys:
+            del self.variables[key]
+
+        if expired_keys:
+            self.updated_at = datetime.utcnow()
+
+        return len(expired_keys)
+
+    def get_summary_stats(self) -> ConversationSummary:
+        """Generate conversation summary statistics."""
+        user_msgs = sum(1 for msg in self.history if msg.role == ConversationRole.USER)
+        assistant_msgs = sum(1 for msg in self.history if msg.role == ConversationRole.ASSISTANT)
+        total_tokens = sum(msg.tokens or 0 for msg in self.history if msg.tokens)
+
+        first_msg = self.history[0] if self.history else None
+        last_msg = self.history[-1] if self.history else None
+
+        return ConversationSummary(
+            total_messages=len(self.history) + self.archived_messages,
+            user_messages=user_msgs,
+            assistant_messages=assistant_msgs,
+            total_tokens=total_tokens if total_tokens > 0 else None,
+            first_message_at=first_msg.timestamp if first_msg else None,
+            last_message_at=last_msg.timestamp if last_msg else None,
+            topics=self.tags.copy(),
+            summary_text=self.summary.summary_text if self.summary else None
+        )
+
+    def _determine_type(self, value: Any) -> StateVariableType:
+        """Determine the type of a value."""
+        if isinstance(value, str):
+            return StateVariableType.STRING
+        elif isinstance(value, bool):
+            return StateVariableType.BOOLEAN
+        elif isinstance(value, int):
+            return StateVariableType.INTEGER
+        elif isinstance(value, float):
+            return StateVariableType.FLOAT
+        elif isinstance(value, list):
+            return StateVariableType.LIST
+        elif isinstance(value, dict):
+            return StateVariableType.DICT
+        elif isinstance(value, bytes):
+            return StateVariableType.BINARY
+        else:
+            return StateVariableType.JSON
+
+    def _archive_old_messages(self) -> None:
+        """Archive old messages when history is full."""
+        # Keep recent messages, archive the rest
+        keep_count = self.max_history_size // 2
+        to_archive = self.history[:-keep_count]
+        self.history = self.history[-keep_count:]
+        self.archived_messages += len(to_archive)
+
+        # Update summary
+        if not self.summary:
+            self.summary = ConversationSummary(
+                total_messages=0,
+                user_messages=0,
+                assistant_messages=0
+            )
+
+        # Update counts
+        self.summary.total_messages += len(to_archive)
+        self.summary.user_messages += sum(
+            1 for msg in to_archive if msg.role == ConversationRole.USER
+        )
+        self.summary.assistant_messages += sum(
+            1 for msg in to_archive if msg.role == ConversationRole.ASSISTANT
+        )
+
+
+class StateBackendType(str, Enum):
+    """State storage backend types."""
+    MEMORY = "memory"
+    REDIS = "redis"
+    FILE = "file"
+    DATABASE = "database"
+
+
+class StateBackendConfig(BaseModel):
+    """Configuration for state storage backend."""
+    type: StateBackendType = Field(..., description="Backend type")
+
+    # Common settings
+    ttl: TTL = Field(3600, description="Default TTL in seconds")
+    max_size: int = Field(10000, description="Maximum entries")
+    compression: bool = Field(False, description="Enable compression")
+
+    # Connection settings
+    connection_string: str | None = Field(None, description="Connection string")
+    host: str | None = Field(None, description="Host address")
+    port: int | None = Field(None, description="Port number")
+    database: str | None = Field(None, description="Database name")
+
+    # Authentication
+    username: str | None = Field(None, description="Username")
+    password: str | None = Field(None, description="Password")
+
+    # Redis-specific settings
+    redis_settings: ConfigDict = Field(default_factory=dict, description="Redis-specific config")
+
+    # File-specific settings
+    file_path: FilePath | None = Field(None, description="File storage path")
+
+    # Database-specific settings
+    table_name: str = Field("conversation_state", description="Database table name")
+
+    # Performance settings
+    connection_pool_size: int = Field(10, description="Connection pool size")
+    connection_timeout: int = Field(30, description="Connection timeout in seconds")
+    retry_attempts: int = Field(3, description="Retry attempts")
+
+    @field_validator("ttl", "max_size")
+    @classmethod
+    def validate_positive_values(cls, v: int) -> int:
+        """Validate positive values."""
+        if v <= 0:
+            raise ValueError("Value must be positive")
+        return v
+
+    @field_validator("port")
+    @classmethod
+    def validate_port(cls, v: int | None) -> int | None:
+        """Validate port number."""
+        if v is not None and not (1 <= v <= 65535):
+            raise ValueError("Port must be between 1 and 65535")
+        return v
+
+
+class StateOperationType(str, Enum):
+    """Types of state operations."""
+    GET = "get"
+    SET = "set"
+    DELETE = "delete"
+    LIST = "list"
+    CLEANUP = "cleanup"
+
+
+class StateOperation(BaseModel):
+    """State operation for logging and debugging."""
+    operation_id: str = Field(..., description="Operation identifier")
+    operation_type: StateOperationType = Field(..., description="Operation type")
+    context_id: str = Field(..., description="Context identifier")
+    key: str | None = Field(None, description="Variable key")
+
+    # Timing
+    timestamp: Timestamp = Field(default_factory=datetime.utcnow, description="Operation timestamp")
+    duration_ms: float | None = Field(None, description="Operation duration")
+
+    # Result
+    success: bool = Field(..., description="Operation success")
+    error_message: str | None = Field(None, description="Error message if failed")
+
+    # Metadata
+    user_id: UserId | None = Field(None, description="User who performed operation")
+    metadata: dict[str, str] = Field(default_factory=dict, description="Additional metadata")
+
+
+class StateMetrics(BaseModel):
+    """State management metrics."""
+    # Counts
+    total_contexts: int = Field(0, description="Total conversation contexts")
+    total_variables: int = Field(0, description="Total state variables")
+    total_messages: int = Field(0, description="Total messages")
+
+    # Size metrics
+    avg_variables_per_context: float = Field(0.0, description="Average variables per context")
+    avg_messages_per_context: float = Field(0.0, description="Average messages per context")
+
+    # Performance metrics
+    avg_get_latency_ms: float = Field(0.0, description="Average get operation latency")
+    avg_set_latency_ms: float = Field(0.0, description="Average set operation latency")
+
+    # Backend metrics
+    backend_type: StateBackendType = Field(..., description="Backend type")
+    backend_health: Literal["healthy", "degraded", "unhealthy"] = Field(
+        "healthy", description="Backend health status"
+    )
+
+    # Time window
+    measurement_window: timedelta = Field(..., description="Measurement time window")
+    measured_at: Timestamp = Field(default_factory=datetime.utcnow, description="Measurement time")
+
+
+class StateConfig(BaseModel):
+    """Complete state management configuration."""
+    enabled: bool = Field(True, description="Enable state management")
+
+    # Backend configuration
+    backend: StateBackendConfig = Field(..., description="Storage backend configuration")
+
+    # Default limits
+    default_max_history: int = Field(100, description="Default max history size")
+    default_max_variables: int = Field(1000, description="Default max variables")
+    default_ttl: TTL = Field(3600, description="Default variable TTL")
+
+    # Cleanup configuration
+    cleanup_enabled: bool = Field(True, description="Enable automatic cleanup")
+    cleanup_interval: int = Field(300, description="Cleanup interval in seconds")
+    expired_cleanup_batch_size: int = Field(100, description="Expired items cleanup batch size")
+
+    # Performance settings
+    cache_enabled: bool = Field(True, description="Enable in-memory caching")
+    cache_size: int = Field(1000, description="Cache size")
+    cache_ttl: TTL = Field(300, description="Cache TTL")
+
+    # Monitoring
+    metrics_enabled: bool = Field(True, description="Enable metrics collection")
+    operation_logging: bool = Field(False, description="Log all operations")
+
+    @field_validator("default_max_history", "default_max_variables", "cache_size")
+    @classmethod
+    def validate_positive_limits(cls, v: int) -> int:
+        """Validate positive limit values."""
+        if v <= 0:
+            raise ValueError("Limit must be positive")
+        return v
+
+
+# Re-export key models
+__all__ = [
+    "StateVariable",
+    "StateVariableType",
+    "ConversationRole",
+    "ConversationMessage",
+    "ConversationSummary",
+    "ConversationState",
+    "StateBackendType",
+    "StateBackendConfig",
+    "StateOperation",
+    "StateOperationType",
+    "StateMetrics",
+    "StateConfig",
+]

--- a/src/agent/types.py
+++ b/src/agent/types.py
@@ -4,6 +4,7 @@ Core type definitions for AgentUp.
 This module provides common type aliases and utility types used throughout
 the AgentUp codebase to ensure consistent typing.
 """
+
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -87,9 +88,11 @@ TableName = str
 ColumnName = str
 PrimaryKey = str | int
 
+
 # Common constants as types
 class HttpMethod:
     """HTTP method constants."""
+
     GET = "GET"
     POST = "POST"
     PUT = "PUT"
@@ -98,8 +101,10 @@ class HttpMethod:
     HEAD = "HEAD"
     OPTIONS = "OPTIONS"
 
+
 class ContentType:
     """Common content type constants."""
+
     JSON = "application/json"
     XML = "application/xml"
     TEXT = "text/plain"
@@ -108,52 +113,79 @@ class ContentType:
     MULTIPART = "multipart/form-data"
     BINARY = "application/octet-stream"
 
+
 class AuthScheme:
     """Authentication scheme constants."""
+
     BEARER = "Bearer"
     BASIC = "Basic"
     API_KEY = "ApiKey"
     OAUTH2 = "OAuth2"
 
+
 # Re-export commonly used types
 __all__ = [
     # Core JSON type
     "JsonValue",
-
     # Identity types
-    "UserId", "ScopeName", "IPAddress", "ModulePath", "FilePath",
-
+    "UserId",
+    "ScopeName",
+    "IPAddress",
+    "ModulePath",
+    "FilePath",
     # HTTP types
-    "HeaderName", "QueryParam", "CookieName", "Headers", "QueryParams", "FormData",
-
+    "HeaderName",
+    "QueryParam",
+    "CookieName",
+    "Headers",
+    "QueryParams",
+    "FormData",
     # Configuration types
-    "ConfigDict", "MetadataDict", "EnvironmentDict",
-
+    "ConfigDict",
+    "MetadataDict",
+    "EnvironmentDict",
     # Time types
-    "Timestamp", "Duration", "TTL",
-
+    "Timestamp",
+    "Duration",
+    "TTL",
     # Service types
-    "ServiceName", "ServiceType", "ServiceId",
-
+    "ServiceName",
+    "ServiceType",
+    "ServiceId",
     # Plugin types
-    "PluginId", "CapabilityId", "HookName",
-
+    "PluginId",
+    "CapabilityId",
+    "HookName",
     # Security types
-    "Token", "Hash", "Salt", "Signature",
-
+    "Token",
+    "Hash",
+    "Salt",
+    "Signature",
     # MCP types
-    "MCPServerName", "MCPToolName", "MCPResourceId",
-
+    "MCPServerName",
+    "MCPToolName",
+    "MCPResourceId",
     # API types
-    "RequestId", "TaskId", "SessionId", "CorrelationId",
-
+    "RequestId",
+    "TaskId",
+    "SessionId",
+    "CorrelationId",
     # Error types
-    "ErrorCode", "ErrorMessage",
-
+    "ErrorCode",
+    "ErrorMessage",
     # Other types
-    "Version", "URL", "WebSocketURL", "FileContent", "MimeType",
-    "LogLevel", "LoggerName", "TableName", "ColumnName", "PrimaryKey",
-
+    "Version",
+    "URL",
+    "WebSocketURL",
+    "FileContent",
+    "MimeType",
+    "LogLevel",
+    "LoggerName",
+    "TableName",
+    "ColumnName",
+    "PrimaryKey",
     # Constants
-    "HttpMethod", "ContentType", "AuthScheme",
+    "HttpMethod",
+    "ContentType",
+    "AuthScheme",
 ]

--- a/src/agent/types.py
+++ b/src/agent/types.py
@@ -1,0 +1,159 @@
+"""
+Core type definitions for AgentUp.
+
+This module provides common type aliases and utility types used throughout
+the AgentUp codebase to ensure consistent typing.
+"""
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Common type aliases
+UserId = str
+ScopeName = str
+IPAddress = str
+ModulePath = str
+FilePath = str | Path
+HeaderName = str
+QueryParam = str
+CookieName = str
+
+# HTTP-related types
+Headers = dict[str, str]
+QueryParams = dict[str, str | list[str]]
+FormData = dict[str, str | list[str]]
+
+# JSON-compatible value type (using Any to avoid recursion)
+JsonValue = Any
+
+# Configuration types
+ConfigDict = dict[str, Any]
+MetadataDict = dict[str, str]
+EnvironmentDict = dict[str, str]
+
+# Time-related types
+Timestamp = datetime
+Duration = float  # seconds
+TTL = int  # seconds
+
+# Service types
+ServiceName = str
+ServiceType = str
+ServiceId = str
+
+# Plugin types
+PluginId = str
+CapabilityId = str
+HookName = str
+
+# Security types
+Token = str
+Hash = str
+Salt = str
+Signature = str
+
+# MCP types
+MCPServerName = str
+MCPToolName = str
+MCPResourceId = str
+
+# API types
+RequestId = str
+TaskId = str
+SessionId = str
+CorrelationId = str
+
+# Error types
+ErrorCode = str
+ErrorMessage = str
+
+# Version type
+Version = str
+
+# URL types
+URL = str
+WebSocketURL = str
+
+# File content types
+FileContent = str | bytes
+MimeType = str
+
+# Logging types
+LogLevel = str
+LoggerName = str
+
+# Database types (for future use)
+TableName = str
+ColumnName = str
+PrimaryKey = str | int
+
+# Common constants as types
+class HttpMethod:
+    """HTTP method constants."""
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    PATCH = "PATCH"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+
+class ContentType:
+    """Common content type constants."""
+    JSON = "application/json"
+    XML = "application/xml"
+    TEXT = "text/plain"
+    HTML = "text/html"
+    FORM = "application/x-www-form-urlencoded"
+    MULTIPART = "multipart/form-data"
+    BINARY = "application/octet-stream"
+
+class AuthScheme:
+    """Authentication scheme constants."""
+    BEARER = "Bearer"
+    BASIC = "Basic"
+    API_KEY = "ApiKey"
+    OAUTH2 = "OAuth2"
+
+# Re-export commonly used types
+__all__ = [
+    # Core JSON type
+    "JsonValue",
+
+    # Identity types
+    "UserId", "ScopeName", "IPAddress", "ModulePath", "FilePath",
+
+    # HTTP types
+    "HeaderName", "QueryParam", "CookieName", "Headers", "QueryParams", "FormData",
+
+    # Configuration types
+    "ConfigDict", "MetadataDict", "EnvironmentDict",
+
+    # Time types
+    "Timestamp", "Duration", "TTL",
+
+    # Service types
+    "ServiceName", "ServiceType", "ServiceId",
+
+    # Plugin types
+    "PluginId", "CapabilityId", "HookName",
+
+    # Security types
+    "Token", "Hash", "Salt", "Signature",
+
+    # MCP types
+    "MCPServerName", "MCPToolName", "MCPResourceId",
+
+    # API types
+    "RequestId", "TaskId", "SessionId", "CorrelationId",
+
+    # Error types
+    "ErrorCode", "ErrorMessage",
+
+    # Other types
+    "Version", "URL", "WebSocketURL", "FileContent", "MimeType",
+    "LogLevel", "LoggerName", "TableName", "ColumnName", "PrimaryKey",
+
+    # Constants
+    "HttpMethod", "ContentType", "AuthScheme",
+]

--- a/src/agent/utils/validation.py
+++ b/src/agent/utils/validation.py
@@ -1,0 +1,594 @@
+"""
+Validation framework for AgentUp Pydantic models.
+
+This module provides base validation classes and utilities for comprehensive
+model validation beyond Pydantic's built-in capabilities.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel, Field, ValidationError
+
+# Generic type for model validators
+T = TypeVar('T', bound=BaseModel)
+
+
+class ValidationResult(BaseModel):
+    """Result of model validation with detailed feedback."""
+    valid: bool = Field(..., description="Whether validation passed")
+    errors: list[str] = Field(default_factory=list, description="Validation errors")
+    warnings: list[str] = Field(default_factory=list, description="Validation warnings")
+    suggestions: list[str] = Field(default_factory=list, description="Improvement suggestions")
+    field_errors: dict[str, list[str]] = Field(
+        default_factory=dict, description="Field-specific errors"
+    )
+
+    def add_error(self, message: str, field: str | None = None) -> None:
+        """Add a validation error."""
+        self.valid = False
+        self.errors.append(message)
+        if field:
+            if field not in self.field_errors:
+                self.field_errors[field] = []
+            self.field_errors[field].append(message)
+
+    def add_warning(self, message: str) -> None:
+        """Add a validation warning."""
+        self.warnings.append(message)
+
+    def add_suggestion(self, message: str) -> None:
+        """Add an improvement suggestion."""
+        self.suggestions.append(message)
+
+    def merge(self, other: ValidationResult) -> None:
+        """Merge another validation result into this one."""
+        if not other.valid:
+            self.valid = False
+        self.errors.extend(other.errors)
+        self.warnings.extend(other.warnings)
+        self.suggestions.extend(other.suggestions)
+
+        # Merge field errors
+        for field, field_errors in other.field_errors.items():
+            if field not in self.field_errors:
+                self.field_errors[field] = []
+            self.field_errors[field].extend(field_errors)
+
+    @property
+    def has_errors(self) -> bool:
+        """Check if there are any errors."""
+        return len(self.errors) > 0 or len(self.field_errors) > 0
+
+    @property
+    def has_warnings(self) -> bool:
+        """Check if there are any warnings."""
+        return len(self.warnings) > 0
+
+    @property
+    def summary(self) -> str:
+        """Get a summary of the validation result."""
+        parts = []
+        if self.errors:
+            parts.append(f"{len(self.errors)} errors")
+        if self.warnings:
+            parts.append(f"{len(self.warnings)} warnings")
+        if self.suggestions:
+            parts.append(f"{len(self.suggestions)} suggestions")
+
+        if not parts:
+            return "Validation passed"
+        return f"Validation completed with {', '.join(parts)}"
+
+
+class BaseValidator(ABC, Generic[T]):
+    """Abstract base validator for all models."""
+
+    def __init__(self, model_class: type[T]):
+        """Initialize validator with model class."""
+        self.model_class = model_class
+
+    @abstractmethod
+    def validate(self, model: T) -> ValidationResult:
+        """Validate a model instance.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with validation details
+        """
+        pass
+
+    def validate_dict(self, data: dict[str, Any]) -> ValidationResult:
+        """Validate a dictionary against the model.
+
+        Args:
+            data: Dictionary data to validate
+
+        Returns:
+            ValidationResult with validation details
+        """
+        try:
+            model = self.model_class(**data)
+            return self.validate(model)
+        except ValidationError as e:
+            result = ValidationResult(valid=False)
+            for error in e.errors():
+                field_path = ".".join(str(loc) for loc in error["loc"])
+                message = f"{field_path}: {error['msg']}"
+                result.add_error(message, field_path)
+            return result
+        except Exception as e:
+            result = ValidationResult(valid=False)
+            result.add_error(f"Unexpected validation error: {str(e)}")
+            return result
+
+    def validate_json(self, json_data: str) -> ValidationResult:
+        """Validate JSON string against the model.
+
+        Args:
+            json_data: JSON string to validate
+
+        Returns:
+            ValidationResult with validation details
+        """
+        try:
+            import json
+            data = json.loads(json_data)
+            return self.validate_dict(data)
+        except json.JSONDecodeError as e:
+            result = ValidationResult(valid=False)
+            result.add_error(f"Invalid JSON: {str(e)}")
+            return result
+
+
+class CompositeValidator(BaseValidator[T]):
+    """Composite validator that runs multiple validators."""
+
+    def __init__(self, model_class: type[T], validators: list[BaseValidator[T]]):
+        """Initialize with list of validators.
+
+        Args:
+            model_class: The model class to validate
+            validators: List of validators to run
+        """
+        super().__init__(model_class)
+        self.validators = validators
+
+    def validate(self, model: T) -> ValidationResult:
+        """Run all validators and combine results.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            Combined ValidationResult from all validators
+        """
+        result = ValidationResult(valid=True)
+
+        for validator in self.validators:
+            sub_result = validator.validate(model)
+            result.merge(sub_result)
+
+        return result
+
+
+class ConditionalValidator(BaseValidator[T]):
+    """Validator that applies conditions before validation."""
+
+    def __init__(
+        self,
+        model_class: type[T],
+        condition: callable,
+        validator: BaseValidator[T],
+        skip_message: str | None = None
+    ):
+        """Initialize conditional validator.
+
+        Args:
+            model_class: The model class to validate
+            condition: Function that takes model and returns bool
+            validator: Validator to run if condition is true
+            skip_message: Message to add if validation is skipped
+        """
+        super().__init__(model_class)
+        self.condition = condition
+        self.validator = validator
+        self.skip_message = skip_message
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model if condition is met.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult from conditional validation
+        """
+        if not self.condition(model):
+            result = ValidationResult(valid=True)
+            if self.skip_message:
+                result.add_suggestion(self.skip_message)
+            return result
+
+        return self.validator.validate(model)
+
+
+class FieldValidator(BaseValidator[T]):
+    """Validator for specific model fields."""
+
+    def __init__(self, model_class: type[T]):
+        """Initialize field validator."""
+        super().__init__(model_class)
+        self.field_validators: dict[str, list[callable]] = {}
+
+    def add_field_validator(self, field_name: str, validator_func: callable) -> None:
+        """Add a validator function for a specific field.
+
+        Args:
+            field_name: Name of the field to validate
+            validator_func: Function that takes field value and returns str|None (error message)
+        """
+        if field_name not in self.field_validators:
+            self.field_validators[field_name] = []
+        self.field_validators[field_name].append(validator_func)
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model fields.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with field validation details
+        """
+        result = ValidationResult(valid=True)
+
+        for field_name, validators in self.field_validators.items():
+            if not hasattr(model, field_name):
+                continue
+
+            field_value = getattr(model, field_name)
+
+            for validator_func in validators:
+                try:
+                    error_message = validator_func(field_value)
+                    if error_message:
+                        result.add_error(error_message, field_name)
+                except Exception as e:
+                    result.add_error(
+                        f"Field validator error: {str(e)}",
+                        field_name
+                    )
+
+        return result
+
+
+class SchemaValidator(BaseValidator[T]):
+    """Validator for JSON Schema compliance."""
+
+    def __init__(self, model_class: type[T], schema: dict[str, Any]):
+        """Initialize with JSON schema.
+
+        Args:
+            model_class: The model class to validate
+            schema: JSON schema to validate against
+        """
+        super().__init__(model_class)
+        self.schema = schema
+
+        try:
+            import jsonschema
+            self.jsonschema = jsonschema
+        except ImportError:
+            raise ImportError("jsonschema package required for SchemaValidator") from None
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model against JSON schema.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with schema validation details
+        """
+        result = ValidationResult(valid=True)
+
+        try:
+            # Convert model to dict for schema validation
+            model_dict = model.dict()
+            self.jsonschema.validate(model_dict, self.schema)
+        except self.jsonschema.ValidationError as e:
+            result.add_error(f"Schema validation error: {e.message}", e.absolute_path)
+        except Exception as e:
+            result.add_error(f"Schema validation failed: {str(e)}")
+
+        return result
+
+
+class BusinessRuleValidator(BaseValidator[T]):
+    """Validator for business logic rules."""
+
+    def __init__(self, model_class: type[T]):
+        """Initialize business rule validator."""
+        super().__init__(model_class)
+        self.rules: list[callable] = []
+
+    def add_rule(self, rule_func: callable, error_message: str | None = None) -> None:
+        """Add a business rule validation function.
+
+        Args:
+            rule_func: Function that takes model and returns bool (True = valid)
+            error_message: Custom error message if rule fails
+        """
+        def wrapper(model):
+            try:
+                if not rule_func(model):
+                    return error_message or f"Business rule validation failed: {rule_func.__name__}"
+                return None
+            except Exception as e:
+                return f"Business rule error: {str(e)}"
+
+        self.rules.append(wrapper)
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model against business rules.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with business rule validation details
+        """
+        result = ValidationResult(valid=True)
+
+        for rule in self.rules:
+            error_message = rule(model)
+            if error_message:
+                result.add_error(error_message)
+
+        return result
+
+
+class CrossFieldValidator(BaseValidator[T]):
+    """Validator for cross-field dependencies and constraints."""
+
+    def __init__(self, model_class: type[T]):
+        """Initialize cross-field validator."""
+        super().__init__(model_class)
+        self.constraints: list[callable] = []
+
+    def add_constraint(
+        self,
+        fields: list[str],
+        constraint_func: callable,
+        error_message: str | None = None
+    ) -> None:
+        """Add a cross-field constraint.
+
+        Args:
+            fields: List of field names involved in constraint
+            constraint_func: Function that takes field values and returns bool
+            error_message: Custom error message if constraint fails
+        """
+        def wrapper(model):
+            try:
+                field_values = {}
+                for field in fields:
+                    if hasattr(model, field):
+                        field_values[field] = getattr(model, field)
+
+                if not constraint_func(**field_values):
+                    return error_message or f"Cross-field constraint failed for fields: {', '.join(fields)}"
+                return None
+            except Exception as e:
+                return f"Cross-field constraint error: {str(e)}"
+
+        self.constraints.append(wrapper)
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model cross-field constraints.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with cross-field validation details
+        """
+        result = ValidationResult(valid=True)
+
+        for constraint in self.constraints:
+            error_message = constraint(model)
+            if error_message:
+                result.add_error(error_message)
+
+        return result
+
+
+class PerformanceValidator(BaseValidator[T]):
+    """Validator for performance characteristics."""
+
+    def __init__(self, model_class: type[T]):
+        """Initialize performance validator."""
+        super().__init__(model_class)
+        self.size_limits: dict[str, int] = {}
+        self.complexity_limits: dict[str, int] = {}
+
+    def set_size_limit(self, field_name: str, max_size: int) -> None:
+        """Set size limit for a field.
+
+        Args:
+            field_name: Name of the field
+            max_size: Maximum allowed size
+        """
+        self.size_limits[field_name] = max_size
+
+    def set_complexity_limit(self, field_name: str, max_complexity: int) -> None:
+        """Set complexity limit for a field.
+
+        Args:
+            field_name: Name of the field
+            max_complexity: Maximum allowed complexity
+        """
+        self.complexity_limits[field_name] = max_complexity
+
+    def validate(self, model: T) -> ValidationResult:
+        """Validate model performance characteristics.
+
+        Args:
+            model: The model instance to validate
+
+        Returns:
+            ValidationResult with performance validation details
+        """
+        result = ValidationResult(valid=True)
+
+        # Check size limits
+        for field_name, max_size in self.size_limits.items():
+            if not hasattr(model, field_name):
+                continue
+
+            field_value = getattr(model, field_name)
+            size = self._calculate_size(field_value)
+
+            if size > max_size:
+                result.add_error(
+                    f"Field '{field_name}' size ({size}) exceeds limit ({max_size})",
+                    field_name
+                )
+
+        # Check complexity limits
+        for field_name, max_complexity in self.complexity_limits.items():
+            if not hasattr(model, field_name):
+                continue
+
+            field_value = getattr(model, field_name)
+            complexity = self._calculate_complexity(field_value)
+
+            if complexity > max_complexity:
+                result.add_error(
+                    f"Field '{field_name}' complexity ({complexity}) exceeds limit ({max_complexity})",
+                    field_name
+                )
+
+        return result
+
+    def _calculate_size(self, value: Any) -> int:
+        """Calculate size of a value."""
+        if isinstance(value, str):
+            return len(value)
+        elif isinstance(value, list | dict | set):
+            return len(value)
+        elif isinstance(value, bytes):
+            return len(value)
+        else:
+            return 1
+
+    def _calculate_complexity(self, value: Any) -> int:
+        """Calculate complexity of a value."""
+        if isinstance(value, dict):
+            return sum(1 + self._calculate_complexity(v) for v in value.values())
+        elif isinstance(value, list):
+            return sum(1 + self._calculate_complexity(item) for item in value)
+        else:
+            return 1
+
+
+# Utility functions for common validation patterns
+def validate_url(url: str) -> str | None:
+    """Validate URL format.
+
+    Args:
+        url: URL to validate
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not url:
+        return "URL cannot be empty"
+
+    if not url.startswith(('http://', 'https://')):
+        return "URL must start with http:// or https://"
+
+    # Basic URL format check
+    import re
+    url_pattern = re.compile(
+        r'^https?://'  # http:// or https://
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?|'  # domain...
+        r'localhost|'  # localhost...
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
+        r'(?::\d+)?'  # optional port
+        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
+    if not url_pattern.match(url):
+        return "Invalid URL format"
+
+    return None
+
+
+def validate_email(email: str) -> str | None:
+    """Validate email format.
+
+    Args:
+        email: Email to validate
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not email:
+        return "Email cannot be empty"
+
+    import re
+    email_pattern = re.compile(
+        r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    )
+
+    if not email_pattern.match(email):
+        return "Invalid email format"
+
+    return None
+
+
+def validate_version(version: str) -> str | None:
+    """Validate semantic version format.
+
+    Args:
+        version: Version string to validate
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not version:
+        return "Version cannot be empty"
+
+    import re
+    version_pattern = re.compile(
+        r'^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)'
+        r'(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)'
+        r'(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)'
+        r')?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+    )
+
+    if not version_pattern.match(version):
+        return "Invalid semantic version format (expected: major.minor.patch)"
+
+    return None
+
+
+# Re-export key classes
+__all__ = [
+    "ValidationResult",
+    "BaseValidator",
+    "CompositeValidator",
+    "ConditionalValidator",
+    "FieldValidator",
+    "SchemaValidator",
+    "BusinessRuleValidator",
+    "CrossFieldValidator",
+    "PerformanceValidator",
+    "validate_url",
+    "validate_email",
+    "validate_version",
+]

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,521 @@
+"""
+Tests for AgentUp configuration models.
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.agent.config.model import (
+    AgentConfig,
+    APIConfig,
+    ConfigurationSettings,
+    LogFormat,
+    LoggingConfig,
+    MCPConfig,
+    MCPServerConfig,
+    PluginCapabilityConfig,
+    PluginConfig,
+    ServiceConfig,
+    expand_env_vars,
+)
+
+
+class TestLoggingConfig:
+    """Test LoggingConfig model."""
+
+    def test_default_logging_config(self):
+        """Test default logging configuration."""
+        config = LoggingConfig()
+
+        assert config.enabled is True
+        assert config.level == "INFO"
+        assert config.format == LogFormat.TEXT
+        assert config.console.enabled is True
+        assert config.correlation_id is True
+        assert config.request_logging is True
+
+    def test_custom_logging_config(self):
+        """Test custom logging configuration."""
+        config = LoggingConfig(
+            level="DEBUG",
+            format=LogFormat.JSON,
+            modules={"security": "WARNING", "api": "DEBUG"}
+        )
+
+        assert config.level == "DEBUG"
+        assert config.format == LogFormat.JSON
+        assert config.modules["security"] == "WARNING"
+        assert config.modules["api"] == "DEBUG"
+
+    def test_invalid_log_level(self):
+        """Test invalid log level validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            LoggingConfig(level="INVALID")
+
+        assert "Invalid log level" in str(exc_info.value)
+
+    def test_log_level_case_insensitive(self):
+        """Test log level case insensitive validation."""
+        config = LoggingConfig(level="debug")
+        assert config.level == "DEBUG"
+
+        config = LoggingConfig(modules={"test": "warning"})
+        assert config.modules["test"] == "WARNING"
+
+
+class TestServiceConfig:
+    """Test ServiceConfig model."""
+
+    def test_default_service_config(self):
+        """Test default service configuration."""
+        config = ServiceConfig(type="llm")
+
+        assert config.type == "llm"
+        assert config.enabled is True
+        assert config.priority == 50
+        assert config.health_check_enabled is True
+        assert config.max_retries == 3
+
+    def test_custom_service_config(self):
+        """Test custom service configuration."""
+        config = ServiceConfig(
+            type="custom-service",
+            enabled=False,
+            priority=10,
+            settings={"api_key": "secret", "timeout": 30}
+        )
+
+        assert config.type == "custom-service"
+        assert config.enabled is False
+        assert config.priority == 10
+        assert config.settings["api_key"] == "secret"
+        assert config.settings["timeout"] == 30
+
+    def test_service_type_validation(self):
+        """Test service type validation."""
+        # Valid types
+        ServiceConfig(type="llm")
+        ServiceConfig(type="database")
+        ServiceConfig(type="custom_service")
+        ServiceConfig(type="service-name")
+
+        # Invalid types
+        with pytest.raises(ValidationError):
+            ServiceConfig(type="")
+
+        with pytest.raises(ValidationError):
+            ServiceConfig(type="invalid service!")
+
+    def test_priority_validation(self):
+        """Test priority validation."""
+        ServiceConfig(type="test", priority=0)
+        ServiceConfig(type="test", priority=100)
+
+        with pytest.raises(ValidationError):
+            ServiceConfig(type="test", priority=-1)
+
+        with pytest.raises(ValidationError):
+            ServiceConfig(type="test", priority=101)
+
+
+class TestAPIConfig:
+    """Test APIConfig model."""
+
+    def test_default_api_config(self):
+        """Test default API configuration."""
+        config = APIConfig()
+
+        assert config.enabled is True
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+        assert config.workers == 1
+        assert config.cors_enabled is True
+        assert "*" in config.cors_origins
+
+    def test_custom_api_config(self):
+        """Test custom API configuration."""
+        config = APIConfig(
+            host="0.0.0.0",
+            port=9000,
+            workers=4,
+            cors_origins=["https://example.com", "https://app.example.com"]
+        )
+
+        assert config.host == "0.0.0.0"
+        assert config.port == 9000
+        assert config.workers == 4
+        assert "https://example.com" in config.cors_origins
+
+    def test_port_validation(self):
+        """Test port number validation."""
+        APIConfig(port=1)
+        APIConfig(port=65535)
+
+        with pytest.raises(ValidationError):
+            APIConfig(port=0)
+
+        with pytest.raises(ValidationError):
+            APIConfig(port=65536)
+
+    def test_workers_validation(self):
+        """Test workers count validation."""
+        APIConfig(workers=1)
+        APIConfig(workers=32)
+
+        with pytest.raises(ValidationError):
+            APIConfig(workers=0)
+
+        with pytest.raises(ValidationError):
+            APIConfig(workers=33)
+
+
+class TestMCPConfig:
+    """Test MCP configuration models."""
+
+    def test_mcp_server_config_stdio(self):
+        """Test MCP server config for stdio type."""
+        config = MCPServerConfig(
+            name="test-server",
+            type="stdio",
+            command="python",
+            args=["-m", "mcp_server"],
+            env={"DEBUG": "1"}
+        )
+
+        assert config.name == "test-server"
+        assert config.type == "stdio"
+        assert config.command == "python"
+        assert config.args == ["-m", "mcp_server"]
+        assert config.env["DEBUG"] == "1"
+
+    def test_mcp_server_config_http(self):
+        """Test MCP server config for http type."""
+        config = MCPServerConfig(
+            name="http-server",
+            type="http",
+            url="https://api.example.com/mcp",
+            headers={"Authorization": "Bearer token"},
+            timeout=60
+        )
+
+        assert config.name == "http-server"
+        assert config.type == "http"
+        assert config.url == "https://api.example.com/mcp"
+        assert config.headers["Authorization"] == "Bearer token"
+        assert config.timeout == 60
+
+    def test_mcp_server_config_validation(self):
+        """Test MCP server config validation."""
+        # stdio without command should fail
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(name="test", type="stdio")
+        assert "command is required" in str(exc_info.value)
+
+        # http without url should fail
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(name="test", type="http")
+        assert "url is required" in str(exc_info.value)
+
+        # Invalid http url should fail
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(name="test", type="http", url="invalid-url")
+        assert "must start with http" in str(exc_info.value)
+
+    def test_mcp_config(self):
+        """Test complete MCP configuration."""
+        config = MCPConfig(
+            enabled=True,
+            client_enabled=True,
+            server_enabled=True,
+            server_port=9000,
+            servers=[
+                MCPServerConfig(
+                    name="local",
+                    type="stdio",
+                    command="python",
+                    args=["-m", "local_server"]
+                )
+            ]
+        )
+
+        assert config.enabled is True
+        assert config.server_port == 9000
+        assert len(config.servers) == 1
+        assert config.servers[0].name == "local"
+
+
+class TestPluginConfig:
+    """Test plugin configuration models."""
+
+    def test_plugin_capability_config(self):
+        """Test plugin capability configuration."""
+        capability = PluginCapabilityConfig(
+            capability_id="text_processor",
+            name="Text Processing",
+            description="Process text input",
+            required_scopes=["read", "process"],
+            config={"max_length": 1000}
+        )
+
+        assert capability.capability_id == "text_processor"
+        assert capability.name == "Text Processing"
+        assert "read" in capability.required_scopes
+        assert capability.config["max_length"] == 1000
+
+    def test_plugin_config(self):
+        """Test plugin configuration."""
+        plugin = PluginConfig(
+            plugin_id="my.text.plugin",
+            name="Text Plugin",
+            description="A plugin for text processing",
+            capabilities=[
+                PluginCapabilityConfig(
+                    capability_id="process",
+                    required_scopes=["text:read"]
+                )
+            ],
+            default_scopes=["basic"]
+        )
+
+        assert plugin.plugin_id == "my.text.plugin"
+        assert plugin.name == "Text Plugin"
+        assert len(plugin.capabilities) == 1
+        assert plugin.capabilities[0].capability_id == "process"
+        assert "basic" in plugin.default_scopes
+
+    def test_plugin_id_validation(self):
+        """Test plugin ID validation."""
+        # Valid IDs
+        PluginConfig(plugin_id="simple")
+        PluginConfig(plugin_id="my-plugin")
+        PluginConfig(plugin_id="my_plugin")
+        PluginConfig(plugin_id="my.plugin.name")
+        PluginConfig(plugin_id="plugin123")
+
+        # Invalid IDs
+        with pytest.raises(ValidationError):
+            PluginConfig(plugin_id="")
+
+        with pytest.raises(ValidationError):
+            PluginConfig(plugin_id="invalid plugin!")
+
+
+class TestAgentConfig:
+    """Test main agent configuration."""
+
+    def test_default_agent_config(self):
+        """Test default agent configuration."""
+        config = AgentConfig()
+
+        assert config.project_name == "AgentUp"
+        assert config.version == "1.0.0"
+        assert config.services_enabled is True
+        assert config.mcp_enabled is False
+        assert config.environment == "development"
+        assert isinstance(config.logging, LoggingConfig)
+        assert isinstance(config.api, APIConfig)
+
+    def test_custom_agent_config(self):
+        """Test custom agent configuration."""
+        config = AgentConfig(
+            project_name="MyAgent",
+            description="Custom AI agent",
+            version="2.1.0",
+            environment="production",
+            mcp_enabled=True
+        )
+
+        assert config.project_name == "MyAgent"
+        assert config.description == "Custom AI agent"
+        assert config.version == "2.1.0"
+        assert config.environment == "production"
+        assert config.mcp_enabled is True
+
+    def test_project_name_validation(self):
+        """Test project name validation."""
+        AgentConfig(project_name="A")  # Minimum length
+        AgentConfig(project_name="A" * 100)  # Maximum length
+
+        with pytest.raises(ValidationError):
+            AgentConfig(project_name="")
+
+        with pytest.raises(ValidationError):
+            AgentConfig(project_name="A" * 101)
+
+    def test_version_validation(self):
+        """Test semantic version validation."""
+        # Valid versions
+        AgentConfig(version="1.0.0")
+        AgentConfig(version="10.20.30")
+        AgentConfig(version="1.0.0-alpha")
+        AgentConfig(version="1.0.0-beta.1")
+
+        # Invalid versions
+        with pytest.raises(ValidationError):
+            AgentConfig(version="1.0")
+
+        with pytest.raises(ValidationError):
+            AgentConfig(version="v1.0.0")
+
+        with pytest.raises(ValidationError):
+            AgentConfig(version="1.0.0.0")
+
+    def test_mcp_consistency_validation(self):
+        """Test MCP configuration consistency."""
+        config = AgentConfig(mcp_enabled=True)
+
+        # Should auto-enable MCP config
+        assert config.mcp.enabled is True
+
+    def test_services_configuration(self):
+        """Test services configuration."""
+        config = AgentConfig(
+            services={
+                "llm": ServiceConfig(type="openai", settings={"api_key": "secret"}),
+                "database": ServiceConfig(type="postgresql", priority=10)
+            }
+        )
+
+        assert "llm" in config.services
+        assert "database" in config.services
+        assert config.services["llm"].type == "openai"
+        assert config.services["database"].priority == 10
+
+
+class TestConfigurationSettings:
+    """Test environment-based configuration settings."""
+
+    def test_default_settings(self):
+        """Test default configuration settings."""
+        settings = ConfigurationSettings()
+
+        assert settings.CONFIG_FILE == "agentup.yml"
+        assert settings.ENVIRONMENT == "development"
+        assert settings.DEBUG is False
+        assert settings.LOG_LEVEL == "INFO"
+        assert settings.API_HOST == "127.0.0.1"
+        assert settings.API_PORT == 8000
+
+    def test_directory_creation(self):
+        """Test directory creation functionality."""
+        settings = ConfigurationSettings(
+            DATA_DIR="test_data",
+            LOGS_DIR="test_logs",
+            PLUGINS_DIR="test_plugins"
+        )
+
+        # This would create directories in a real environment
+        # Here we just test that the method exists and can be called
+        try:
+            settings.create_directories()
+        except Exception:
+            # Directory creation might fail in test environment, that's ok
+            pass
+
+
+class TestUtilityFunctions:
+    """Test utility functions."""
+
+    def test_expand_env_vars_string(self):
+        """Test environment variable expansion in strings."""
+        import os
+
+        # Set test environment variable
+        os.environ["TEST_VAR"] = "test_value"
+
+        # Test simple expansion
+        result = expand_env_vars("${TEST_VAR}")
+        assert result == "test_value"
+
+        # Test expansion with default
+        result = expand_env_vars("${NONEXISTENT:default}")
+        assert result == "default"
+
+        # Test no expansion needed
+        result = expand_env_vars("plain_string")
+        assert result == "plain_string"
+
+        # Clean up
+        del os.environ["TEST_VAR"]
+
+    def test_expand_env_vars_dict(self):
+        """Test environment variable expansion in dictionaries."""
+        import os
+
+        os.environ["DB_HOST"] = "localhost"
+        os.environ["DB_PORT"] = "5432"
+
+        config = {
+            "database": {
+                "host": "${DB_HOST}",
+                "port": "${DB_PORT}",
+                "name": "mydb"
+            },
+            "debug": "${DEBUG:false}"
+        }
+
+        result = expand_env_vars(config)
+
+        assert result["database"]["host"] == "localhost"
+        assert result["database"]["port"] == "5432"
+        assert result["database"]["name"] == "mydb"
+        assert result["debug"] == "false"
+
+        # Clean up
+        del os.environ["DB_HOST"]
+        del os.environ["DB_PORT"]
+
+    def test_expand_env_vars_list(self):
+        """Test environment variable expansion in lists."""
+        import os
+
+        os.environ["PLUGIN1"] = "auth_plugin"
+
+        config = ["${PLUGIN1}", "logging_plugin", "${PLUGIN2:default_plugin}"]
+
+        result = expand_env_vars(config)
+
+        assert result[0] == "auth_plugin"
+        assert result[1] == "logging_plugin"
+        assert result[2] == "default_plugin"
+
+        # Clean up
+        del os.environ["PLUGIN1"]
+
+
+class TestModelSerialization:
+    """Test model serialization and deserialization."""
+
+    def test_agent_config_serialization(self):
+        """Test agent config serialization."""
+        config = AgentConfig(
+            project_name="TestAgent",
+            version="1.2.3",
+            mcp_enabled=True
+        )
+
+        # Serialize to dict
+        config_dict = config.dict()
+        assert config_dict["project_name"] == "TestAgent"
+        assert config_dict["version"] == "1.2.3"
+        assert config_dict["mcp_enabled"] is True
+        assert isinstance(config_dict["logging"], dict)
+
+        # Deserialize from dict
+        restored_config = AgentConfig(**config_dict)
+        assert restored_config.project_name == "TestAgent"
+        assert restored_config.version == "1.2.3"
+        assert restored_config.mcp_enabled is True
+
+    def test_json_serialization(self):
+        """Test JSON serialization."""
+        config = LoggingConfig(level="DEBUG", format=LogFormat.JSON)
+
+        # Should be able to serialize to JSON
+        json_str = config.model_dump_json()
+        assert '"level":"DEBUG"' in json_str
+        assert '"format":"json"' in json_str
+
+        # Should be able to deserialize from JSON
+        restored_config = LoggingConfig.model_validate_json(json_str)
+        assert restored_config.level == "DEBUG"
+        assert restored_config.format == LogFormat.JSON

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,6 +1,7 @@
 """
 Tests for AgentUp configuration models.
 """
+
 import pytest
 from pydantic import ValidationError
 
@@ -35,11 +36,7 @@ class TestLoggingConfig:
 
     def test_custom_logging_config(self):
         """Test custom logging configuration."""
-        config = LoggingConfig(
-            level="DEBUG",
-            format=LogFormat.JSON,
-            modules={"security": "WARNING", "api": "DEBUG"}
-        )
+        config = LoggingConfig(level="DEBUG", format=LogFormat.JSON, modules={"security": "WARNING", "api": "DEBUG"})
 
         assert config.level == "DEBUG"
         assert config.format == LogFormat.JSON
@@ -78,10 +75,7 @@ class TestServiceConfig:
     def test_custom_service_config(self):
         """Test custom service configuration."""
         config = ServiceConfig(
-            type="custom-service",
-            enabled=False,
-            priority=10,
-            settings={"api_key": "secret", "timeout": 30}
+            type="custom-service", enabled=False, priority=10, settings={"api_key": "secret", "timeout": 30}
         )
 
         assert config.type == "custom-service"
@@ -134,10 +128,7 @@ class TestAPIConfig:
     def test_custom_api_config(self):
         """Test custom API configuration."""
         config = APIConfig(
-            host="0.0.0.0",
-            port=9000,
-            workers=4,
-            cors_origins=["https://example.com", "https://app.example.com"]
+            host="0.0.0.0", port=9000, workers=4, cors_origins=["https://example.com", "https://app.example.com"]
         )
 
         assert config.host == "0.0.0.0"
@@ -174,11 +165,7 @@ class TestMCPConfig:
     def test_mcp_server_config_stdio(self):
         """Test MCP server config for stdio type."""
         config = MCPServerConfig(
-            name="test-server",
-            type="stdio",
-            command="python",
-            args=["-m", "mcp_server"],
-            env={"DEBUG": "1"}
+            name="test-server", type="stdio", command="python", args=["-m", "mcp_server"], env={"DEBUG": "1"}
         )
 
         assert config.name == "test-server"
@@ -194,7 +181,7 @@ class TestMCPConfig:
             type="http",
             url="https://api.example.com/mcp",
             headers={"Authorization": "Bearer token"},
-            timeout=60
+            timeout=60,
         )
 
         assert config.name == "http-server"
@@ -227,14 +214,7 @@ class TestMCPConfig:
             client_enabled=True,
             server_enabled=True,
             server_port=9000,
-            servers=[
-                MCPServerConfig(
-                    name="local",
-                    type="stdio",
-                    command="python",
-                    args=["-m", "local_server"]
-                )
-            ]
+            servers=[MCPServerConfig(name="local", type="stdio", command="python", args=["-m", "local_server"])],
         )
 
         assert config.enabled is True
@@ -253,7 +233,7 @@ class TestPluginConfig:
             name="Text Processing",
             description="Process text input",
             required_scopes=["read", "process"],
-            config={"max_length": 1000}
+            config={"max_length": 1000},
         )
 
         assert capability.capability_id == "text_processor"
@@ -267,13 +247,8 @@ class TestPluginConfig:
             plugin_id="my.text.plugin",
             name="Text Plugin",
             description="A plugin for text processing",
-            capabilities=[
-                PluginCapabilityConfig(
-                    capability_id="process",
-                    required_scopes=["text:read"]
-                )
-            ],
-            default_scopes=["basic"]
+            capabilities=[PluginCapabilityConfig(capability_id="process", required_scopes=["text:read"])],
+            default_scopes=["basic"],
         )
 
         assert plugin.plugin_id == "my.text.plugin"
@@ -321,7 +296,7 @@ class TestAgentConfig:
             description="Custom AI agent",
             version="2.1.0",
             environment="production",
-            mcp_enabled=True
+            mcp_enabled=True,
         )
 
         assert config.project_name == "MyAgent"
@@ -371,7 +346,7 @@ class TestAgentConfig:
         config = AgentConfig(
             services={
                 "llm": ServiceConfig(type="openai", settings={"api_key": "secret"}),
-                "database": ServiceConfig(type="postgresql", priority=10)
+                "database": ServiceConfig(type="postgresql", priority=10),
             }
         )
 
@@ -397,11 +372,7 @@ class TestConfigurationSettings:
 
     def test_directory_creation(self):
         """Test directory creation functionality."""
-        settings = ConfigurationSettings(
-            DATA_DIR="test_data",
-            LOGS_DIR="test_logs",
-            PLUGINS_DIR="test_plugins"
-        )
+        settings = ConfigurationSettings(DATA_DIR="test_data", LOGS_DIR="test_logs", PLUGINS_DIR="test_plugins")
 
         # This would create directories in a real environment
         # Here we just test that the method exists and can be called
@@ -444,14 +415,7 @@ class TestUtilityFunctions:
         os.environ["DB_HOST"] = "localhost"
         os.environ["DB_PORT"] = "5432"
 
-        config = {
-            "database": {
-                "host": "${DB_HOST}",
-                "port": "${DB_PORT}",
-                "name": "mydb"
-            },
-            "debug": "${DEBUG:false}"
-        }
+        config = {"database": {"host": "${DB_HOST}", "port": "${DB_PORT}", "name": "mydb"}, "debug": "${DEBUG:false}"}
 
         result = expand_env_vars(config)
 
@@ -487,11 +451,7 @@ class TestModelSerialization:
 
     def test_agent_config_serialization(self):
         """Test agent config serialization."""
-        config = AgentConfig(
-            project_name="TestAgent",
-            version="1.2.3",
-            mcp_enabled=True
-        )
+        config = AgentConfig(project_name="TestAgent", version="1.2.3", mcp_enabled=True)
 
         # Serialize to dict
         config_dict = config.dict()

--- a/tests/test_security_models.py
+++ b/tests/test_security_models.py
@@ -1,0 +1,649 @@
+"""
+Tests for AgentUp security models.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from src.agent.security.model import (
+    APIKeyConfig,
+    APIKeyData,
+    AuditAction,
+    AuditLogEntry,
+    AuditResult,
+    AuthContext,
+    AuthResult,
+    AuthType,
+    JWTAlgorithm,
+    JWTConfig,
+    OAuth2Config,
+    PermissionCheck,
+    PermissionResult,
+    Scope,
+    SecurityConfig,
+)
+
+
+class TestScope:
+    """Test Scope model."""
+
+    def test_valid_scope_creation(self):
+        """Test creating valid scopes."""
+        scope = Scope(name="read")
+        assert scope.name == "read"
+        assert scope.description is None
+        assert scope.parent is None
+
+        scope_with_desc = Scope(
+            name="api:v1:read",
+            description="Read API v1 resources",
+            parent="api:v1"
+        )
+        assert scope_with_desc.name == "api:v1:read"
+        assert scope_with_desc.description == "Read API v1 resources"
+        assert scope_with_desc.parent == "api:v1"
+
+    def test_scope_validation(self):
+        """Test scope name validation."""
+        # Valid scope names
+        Scope(name="read")
+        Scope(name="write")
+        Scope(name="admin")
+        Scope(name="api:read")
+        Scope(name="api:v1:read")
+        Scope(name="user123:read")
+
+        # Invalid scope names
+        with pytest.raises(ValidationError):
+            Scope(name="Read")  # Uppercase not allowed
+
+        with pytest.raises(ValidationError):
+            Scope(name="read write")  # Spaces not allowed
+
+        with pytest.raises(ValidationError):
+            Scope(name="read-write")  # Hyphens not allowed
+
+        with pytest.raises(ValidationError):
+            Scope(name="read_write")  # Underscores not allowed
+
+        with pytest.raises(ValidationError):
+            Scope(name="")  # Empty not allowed
+
+    def test_scope_hierarchy(self):
+        """Test scope hierarchy checking."""
+        parent_scope = Scope(name="api")
+        child_scope = Scope(name="api:read")
+        grandchild_scope = Scope(name="api:read:user")
+        unrelated_scope = Scope(name="admin")
+
+        assert child_scope.is_subscope_of(parent_scope)
+        assert grandchild_scope.is_subscope_of(parent_scope)
+        assert grandchild_scope.is_subscope_of(child_scope)
+        assert not parent_scope.is_subscope_of(child_scope)
+        assert not unrelated_scope.is_subscope_of(parent_scope)
+
+    def test_scope_equality_and_hashing(self):
+        """Test scope equality and hashing for sets."""
+        scope1 = Scope(name="read")
+        scope2 = Scope(name="read")
+        scope3 = Scope(name="write")
+
+        assert scope1 == scope2
+        assert scope1 != scope3
+
+        # Test in sets
+        scope_set = {scope1, scope2, scope3}
+        assert len(scope_set) == 2  # scope1 and scope2 are the same
+        assert scope1 in scope_set
+        assert scope3 in scope_set
+
+    def test_scope_immutability(self):
+        """Test that scopes are immutable."""
+        scope = Scope(name="read")
+
+        # Should not be able to modify the scope
+        with pytest.raises(ValidationError):
+            scope.name = "write"
+
+
+class TestAPIKeyData:
+    """Test APIKeyData model."""
+
+    def test_valid_api_key(self):
+        """Test creating valid API keys."""
+        # Key with 3+ character types: lowercase, uppercase, digits, special
+        test_key = "Aa1!" + "x" * 28  # 32 chars total with required diversity
+        key = APIKeyData(
+            key=SecretStr(test_key),
+            name="Test Key",
+            scopes=[Scope(name="read"), Scope(name="write")],
+            description="Test API key"
+        )
+
+        assert key.key.get_secret_value() == test_key
+        assert key.name == "Test Key"
+        assert len(key.scopes) == 2
+        assert not key.is_expired
+        assert key.usage_count == 0
+
+    def test_api_key_validation(self):
+        """Test API key validation rules."""
+        # Too short
+        with pytest.raises(ValidationError) as exc_info:
+            APIKeyData(key=SecretStr("short"))
+        assert "at least 32 characters" in str(exc_info.value)
+
+        # Too long
+        with pytest.raises(ValidationError):
+            APIKeyData(key=SecretStr("a" * 129))
+
+        # Insufficient character types
+        with pytest.raises(ValidationError) as exc_info:
+            APIKeyData(key=SecretStr("a" * 32))  # Only lowercase
+        assert "at least 3 different character types" in str(exc_info.value)
+
+        # Valid key with mixed character types
+        APIKeyData(key=SecretStr("Aa1!" * 8))  # 32 chars with 4 types
+
+    def test_api_key_env_var_skip(self):
+        """Test that env var placeholders skip validation."""
+        # Should not raise validation error
+        key = APIKeyData(key=SecretStr("${API_KEY}"))
+        assert key.key.get_secret_value() == "${API_KEY}"
+
+    def test_api_key_expiration(self):
+        """Test API key expiration."""
+        now = datetime.utcnow()
+
+        # Valid expiration (in future)
+        key = APIKeyData(
+            key=SecretStr("Aa1!" * 8),
+            created_at=now,
+            expires_at=now + timedelta(days=30)
+        )
+        assert not key.is_expired
+
+        # Invalid expiration (in past)
+        with pytest.raises(ValidationError):
+            APIKeyData(
+                key=SecretStr("Aa1!" * 8),
+                created_at=now,
+                expires_at=now - timedelta(days=1)
+            )
+
+        # Test expired key
+        past_time = now - timedelta(days=2)
+        expired_key = APIKeyData(
+            key=SecretStr("Aa1!" * 8),
+            created_at=past_time,
+            expires_at=past_time + timedelta(seconds=1)  # Expires 1 second after creation, but still in the past
+        )
+        assert expired_key.is_expired
+
+    def test_scope_checking(self):
+        """Test API key scope checking."""
+        key = APIKeyData(
+            key=SecretStr("Aa1!" * 8),
+            scopes=[
+                Scope(name="api"),
+                Scope(name="read"),
+                Scope(name="user:profile")
+            ]
+        )
+
+        # Direct scope match
+        assert key.has_scope("read")
+        assert key.has_scope(Scope(name="api"))
+
+        # Subscope match
+        assert key.has_scope("api:v1")
+        assert key.has_scope("api:v1:read")
+        assert key.has_scope("user:profile:view")
+
+        # No match
+        assert not key.has_scope("write")
+        assert not key.has_scope("admin")
+
+
+class TestAPIKeyConfig:
+    """Test APIKeyConfig model."""
+
+    def test_valid_api_key_config(self):
+        """Test valid API key configuration."""
+        config = APIKeyConfig(
+            header_name="X-Custom-Key",
+            location="header",
+            keys=[
+                APIKeyData(key=SecretStr("Aa1!" * 8), name="Key 1"),
+                APIKeyData(key=SecretStr("Bb2@" * 8), name="Key 2")
+            ]
+        )
+
+        assert config.header_name == "X-Custom-Key"
+        assert config.location == "header"
+        assert len(config.keys) == 2
+
+    def test_header_name_validation(self):
+        """Test HTTP header name validation."""
+        # Valid header names
+        APIKeyConfig(
+            header_name="X-API-Key",
+            keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+        )
+        APIKeyConfig(
+            header_name="Authorization",
+            keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+        )
+
+        # Invalid header names
+        with pytest.raises(ValidationError):
+            APIKeyConfig(
+                header_name="Invalid Header Name",  # Spaces not allowed
+                keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+            )
+
+    def test_unique_keys_validation(self):
+        """Test that duplicate API keys are not allowed."""
+        same_key = SecretStr("Aa1!" * 8)
+
+        with pytest.raises(ValidationError) as exc_info:
+            APIKeyConfig(
+                keys=[
+                    APIKeyData(key=same_key, name="Key 1"),
+                    APIKeyData(key=same_key, name="Key 2")  # Duplicate
+                ]
+            )
+        assert "Duplicate API keys" in str(exc_info.value)
+
+    def test_location_validation(self):
+        """Test location parameter validation."""
+        valid_locations = ["header", "query", "cookie"]
+
+        for location in valid_locations:
+            APIKeyConfig(
+                location=location,
+                keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+            )
+
+        # Invalid location should be caught by Literal type
+
+
+class TestJWTConfig:
+    """Test JWT configuration."""
+
+    def test_default_jwt_config(self):
+        """Test default JWT configuration."""
+        config = JWTConfig(secret_key=SecretStr("my-secret-key-32-chars-long!!"))
+
+        assert config.algorithm == JWTAlgorithm.HS256
+        assert config.expiration == timedelta(hours=1)
+        assert config.issuer is None
+        assert config.audience is None
+        assert "sub" in config.required_claims
+        assert "exp" in config.required_claims
+
+    def test_asymmetric_jwt_config(self):
+        """Test JWT config with asymmetric algorithms."""
+        # Should require public key for RS/ES algorithms
+        with pytest.raises(ValidationError) as exc_info:
+            JWTConfig(
+                secret_key=SecretStr("private-key"),
+                algorithm=JWTAlgorithm.RS256
+            )
+        assert "Public key required" in str(exc_info.value)
+
+        # Valid asymmetric config
+        config = JWTConfig(
+            secret_key=SecretStr("private-key"),
+            algorithm=JWTAlgorithm.RS256,
+            public_key=SecretStr("public-key")
+        )
+        assert config.algorithm == JWTAlgorithm.RS256
+        assert config.public_key is not None
+
+    def test_custom_jwt_config(self):
+        """Test custom JWT configuration."""
+        config = JWTConfig(
+            secret_key=SecretStr("custom-secret-key-32-chars!!!"),
+            algorithm=JWTAlgorithm.HS512,
+            expiration=timedelta(minutes=30),
+            issuer="agentup",
+            audience="api",
+            required_claims=["sub", "exp", "iat", "custom"]
+        )
+
+        assert config.algorithm == JWTAlgorithm.HS512
+        assert config.expiration == timedelta(minutes=30)
+        assert config.issuer == "agentup"
+        assert config.audience == "api"
+        assert "custom" in config.required_claims
+
+
+class TestOAuth2Config:
+    """Test OAuth2 configuration."""
+
+    def test_valid_oauth2_config(self):
+        """Test valid OAuth2 configuration."""
+        config = OAuth2Config(
+            client_id="client123",
+            client_secret=SecretStr("secret123"),
+            authorization_url="https://auth.example.com/oauth/authorize",
+            token_url="https://auth.example.com/oauth/token",
+            redirect_uri="https://app.example.com/callback",
+            scopes=["read", "write"],
+            jwks_url="https://auth.example.com/.well-known/jwks.json"
+        )
+
+        assert config.client_id == "client123"
+        assert config.validation_strategy == "jwt"
+        assert config.use_pkce is True
+        assert "read" in config.scopes
+
+    def test_oauth2_url_validation(self):
+        """Test OAuth2 URL validation."""
+        # Valid URLs
+        OAuth2Config(
+            client_id="client",
+            client_secret=SecretStr("secret"),
+            authorization_url="https://example.com/auth",
+            token_url="https://example.com/token",
+            redirect_uri="https://app.com/callback",
+            jwks_url="https://example.com/.well-known/jwks.json"  # Required for JWT validation
+        )
+
+        # Invalid URLs
+        with pytest.raises(ValidationError):
+            OAuth2Config(
+                client_id="client",
+                client_secret=SecretStr("secret"),
+                authorization_url="invalid-url",
+                token_url="https://example.com/token",
+                redirect_uri="https://app.com/callback"
+            )
+
+    def test_oauth2_validation_strategy(self):
+        """Test OAuth2 validation strategy requirements."""
+        # JWT strategy requires jwks_url
+        with pytest.raises(ValidationError) as exc_info:
+            OAuth2Config(
+                client_id="client",
+                client_secret=SecretStr("secret"),
+                authorization_url="https://example.com/auth",
+                token_url="https://example.com/token",
+                redirect_uri="https://app.com/callback",
+                validation_strategy="jwt"
+                # Missing jwks_url
+            )
+        assert "jwks_url required" in str(exc_info.value)
+
+        # Introspection strategy requires introspection_endpoint
+        with pytest.raises(ValidationError) as exc_info:
+            OAuth2Config(
+                client_id="client",
+                client_secret=SecretStr("secret"),
+                authorization_url="https://example.com/auth",
+                token_url="https://example.com/token",
+                redirect_uri="https://app.com/callback",
+                validation_strategy="introspection"
+                # Missing introspection_endpoint
+            )
+        assert "introspection_endpoint required" in str(exc_info.value)
+
+
+class TestSecurityConfig:
+    """Test main security configuration."""
+
+    def test_minimal_security_config(self):
+        """Test minimal valid security configuration."""
+        config = SecurityConfig(
+            auth={
+                AuthType.API_KEY: APIKeyConfig(
+                    keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+                )
+            }
+        )
+
+        assert config.enabled is True
+        assert config.require_https is True
+        assert AuthType.API_KEY in config.auth
+        assert isinstance(config.auth[AuthType.API_KEY], APIKeyConfig)
+
+    def test_multiple_auth_methods(self):
+        """Test security config with multiple auth methods."""
+        config = SecurityConfig(
+            auth={
+                AuthType.API_KEY: APIKeyConfig(
+                    keys=[APIKeyData(key=SecretStr("Aa1!" * 8))]
+                ),
+                AuthType.JWT: JWTConfig(
+                    secret_key=SecretStr("jwt-secret-key-32-chars-long!!")
+                )
+            }
+        )
+
+        assert len(config.auth) == 2
+        assert AuthType.API_KEY in config.auth
+        assert AuthType.JWT in config.auth
+
+    def test_empty_auth_validation(self):
+        """Test that empty auth config is invalid."""
+        with pytest.raises(ValidationError) as exc_info:
+            SecurityConfig(auth={})
+        assert "At least one authentication method must be configured" in str(exc_info.value)
+
+    def test_cors_origins_validation(self):
+        """Test CORS origins validation."""
+        # Valid origins
+        SecurityConfig(
+            auth={AuthType.API_KEY: APIKeyConfig(keys=[APIKeyData(key=SecretStr("Aa1!" * 8))])},
+            allowed_origins=["*"]
+        )
+        SecurityConfig(
+            auth={AuthType.API_KEY: APIKeyConfig(keys=[APIKeyData(key=SecretStr("Aa1!" * 8))])},
+            allowed_origins=["https://example.com", "https://app.example.com"]
+        )
+
+        # Invalid origins
+        with pytest.raises(ValidationError):
+            SecurityConfig(
+                auth={AuthType.API_KEY: APIKeyConfig(keys=[APIKeyData(key=SecretStr("Aa1!" * 8))])},
+                allowed_origins=["invalid-origin"]
+            )
+
+    def test_security_config_defaults(self):
+        """Test security configuration defaults."""
+        config = SecurityConfig(
+            auth={AuthType.API_KEY: APIKeyConfig(keys=[APIKeyData(key=SecretStr("Aa1!" * 8))])}
+        )
+
+        assert config.enabled is True
+        assert config.require_https is True
+        assert config.enable_hsts is True
+        assert config.enable_csrf is True
+        assert config.audit_logging is True
+        assert config.audit_log_retention_days == 90
+        assert config.enable_rate_limiting is True
+        assert config.rate_limit_requests == 60
+
+
+class TestAuthContext:
+    """Test authentication context."""
+
+    def test_auth_context_creation(self):
+        """Test creating authentication context."""
+        context = AuthContext(
+            authenticated=True,
+            auth_type=AuthType.API_KEY,
+            auth_result=AuthResult.SUCCESS,
+            user_id="user123",
+            scopes={Scope(name="read"), Scope(name="api:v1")}
+        )
+
+        assert context.authenticated is True
+        assert context.auth_type == AuthType.API_KEY
+        assert context.user_id == "user123"
+        assert len(context.scopes) == 2
+
+    def test_scope_checking_methods(self):
+        """Test scope checking methods."""
+        context = AuthContext(
+            authenticated=True,
+            scopes={
+                Scope(name="api"),
+                Scope(name="read"),
+                Scope(name="user:profile")
+            }
+        )
+
+        # has_scope
+        assert context.has_scope("read")
+        assert context.has_scope("api:v1")  # Subscope
+        assert not context.has_scope("write")
+
+        # has_any_scope
+        assert context.has_any_scope(["read", "write"]) is True
+        assert context.has_any_scope(["write", "delete"]) is False
+
+        # has_all_scopes
+        assert context.has_all_scopes(["read", "api"]) is True
+        assert context.has_all_scopes(["read", "write"]) is False
+
+
+class TestAuditLogEntry:
+    """Test audit log entry."""
+
+    def test_audit_log_creation(self):
+        """Test creating audit log entries."""
+        entry = AuditLogEntry(
+            event_type="auth",
+            action=AuditAction.LOGIN,
+            result=AuditResult.SUCCESS,
+            user_id="user123",
+            ip_address="192.168.1.1"
+        )
+
+        assert entry.event_type == "auth"
+        assert entry.action == AuditAction.LOGIN
+        assert entry.result == AuditResult.SUCCESS
+        assert entry.user_id == "user123"
+        assert entry.ip_address == "192.168.1.1"
+        assert isinstance(entry.timestamp, datetime)
+
+    def test_audit_log_formatting(self):
+        """Test audit log formatting."""
+        entry = AuditLogEntry(
+            event_type="api",
+            action=AuditAction.READ,
+            result=AuditResult.SUCCESS,
+            user_id="user123",
+            resource_type="document",
+            resource_id="doc456",
+            ip_address="10.0.0.1"
+        )
+
+        log_line = entry.to_log_format()
+
+        assert "EVENT=api" in log_line
+        assert "ACTION=read" in log_line
+        assert "RESULT=success" in log_line
+        assert "USER=user123" in log_line
+        assert "RESOURCE=document:doc456" in log_line
+        assert "IP=10.0.0.1" in log_line
+
+    def test_audit_log_with_error(self):
+        """Test audit log with error information."""
+        entry = AuditLogEntry(
+            event_type="auth",
+            action=AuditAction.LOGIN,
+            result=AuditResult.FAILURE,
+            error_message="Invalid credentials"
+        )
+
+        log_line = entry.to_log_format()
+        assert "RESULT=failure" in log_line
+        assert "ERROR=Invalid credentials" in log_line
+
+
+class TestPermissionModels:
+    """Test permission checking models."""
+
+    def test_permission_check(self):
+        """Test permission check model."""
+        check = PermissionCheck(
+            user_id="user123",
+            resource_type="document",
+            resource_id="doc456",
+            action="read",
+            context={"department": "engineering"}
+        )
+
+        assert check.user_id == "user123"
+        assert check.resource_type == "document"
+        assert check.action == "read"
+        assert check.context["department"] == "engineering"
+
+    def test_permission_result(self):
+        """Test permission result model."""
+        result = PermissionResult(
+            granted=False,
+            reason="Insufficient privileges",
+            required_scopes=["document:read"],
+            missing_scopes=["document:read"],
+            conditions=["Must be in same department"]
+        )
+
+        assert result.granted is False
+        assert result.reason == "Insufficient privileges"
+        assert "document:read" in result.required_scopes
+        assert "document:read" in result.missing_scopes
+        assert len(result.conditions) == 1
+
+
+class TestModelSerialization:
+    """Test model serialization."""
+
+    def test_security_config_serialization(self):
+        """Test security config serialization."""
+        config = SecurityConfig(
+            auth={
+                AuthType.API_KEY: APIKeyConfig(
+                    keys=[APIKeyData(key=SecretStr("Aa1!" * 8), name="Test Key")]
+                )
+            },
+            require_https=False
+        )
+
+        # Serialize to dict
+        config_dict = config.model_dump()
+        assert "auth" in config_dict
+        assert config_dict["require_https"] is False
+
+        # Note: SecretStr values are not included in dict() by default
+        # This is correct security behavior
+
+    def test_auth_context_with_sets(self):
+        """Test auth context serialization with sets."""
+        context = AuthContext(
+            authenticated=True,
+            scopes={Scope(name="read"), Scope(name="write")}
+        )
+
+        # Should be able to convert to dict (use mode='json' for better serialization of complex types)
+        context_dict = context.model_dump(mode='json')
+        assert context_dict["authenticated"] is True
+        # Sets are converted to lists in serialization
+        assert isinstance(context_dict["scopes"], list)
+        assert len(context_dict["scopes"]) == 2
+
+    def test_json_serialization_with_datetime(self):
+        """Test JSON serialization with datetime fields."""
+        entry = AuditLogEntry(
+            event_type="test",
+            action=AuditAction.READ,
+            result=AuditResult.SUCCESS
+        )
+
+        # Should serialize datetime properly
+        json_str = entry.model_dump_json()
+        assert entry.timestamp.isoformat() in json_str

--- a/tests/test_state_models.py
+++ b/tests/test_state_models.py
@@ -1,0 +1,726 @@
+"""
+Tests for AgentUp state management models.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from agent.state.model import (
+    ConversationMessage,
+    ConversationRole,
+    ConversationState,
+    StateBackendConfig,
+    StateBackendType,
+    StateConfig,
+    StateMetrics,
+    StateOperation,
+    StateOperationType,
+    StateVariable,
+    StateVariableType,
+)
+
+
+class TestStateVariable:
+    """Test StateVariable model."""
+
+    def test_string_state_variable(self):
+        """Test string state variable."""
+        var = StateVariable[str](
+            key="user_name",
+            value="John Doe",
+            type_name=StateVariableType.STRING,
+            description="User's full name"
+        )
+
+        assert var.key == "user_name"
+        assert var.value == "John Doe"
+        assert var.type_name == StateVariableType.STRING
+        assert var.version == 1
+        assert not var.is_expired
+
+    def test_integer_state_variable(self):
+        """Test integer state variable."""
+        var = StateVariable[int](
+            key="user_age",
+            value=25,
+            type_name=StateVariableType.INTEGER,
+            ttl=3600  # 1 hour
+        )
+
+        assert var.key == "user_age"
+        assert var.value == 25
+        assert var.type_name == StateVariableType.INTEGER
+        assert var.ttl == 3600
+
+    def test_dict_state_variable(self):
+        """Test dictionary state variable."""
+        config_data = {"theme": "dark", "notifications": True}
+        var = StateVariable[dict](
+            key="user_config",
+            value=config_data,
+            type_name=StateVariableType.DICT,
+            tags=["config", "user"]
+        )
+
+        assert var.key == "user_config"
+        assert var.value["theme"] == "dark"
+        assert var.value["notifications"] is True
+        assert "config" in var.tags
+
+    def test_key_validation(self):
+        """Test state variable key validation."""
+        # Valid keys
+        StateVariable(key="valid_key", value="test", type_name=StateVariableType.STRING)
+        StateVariable(key="valid.key", value="test", type_name=StateVariableType.STRING)
+        StateVariable(key="valid-key", value="test", type_name=StateVariableType.STRING)
+        StateVariable(key="valid123", value="test", type_name=StateVariableType.STRING)
+
+        # Invalid keys
+        with pytest.raises(ValidationError):
+            StateVariable(key="", value="test", type_name=StateVariableType.STRING)
+
+        with pytest.raises(ValidationError):
+            StateVariable(key="invalid key!", value="test", type_name=StateVariableType.STRING)
+
+        with pytest.raises(ValidationError):
+            StateVariable(key="a" * 257, value="test", type_name=StateVariableType.STRING)  # Too long
+
+    def test_ttl_validation(self):
+        """Test TTL validation."""
+        # Valid TTL
+        StateVariable(key="test", value="test", type_name=StateVariableType.STRING, ttl=3600)
+        StateVariable(key="test", value="test", type_name=StateVariableType.STRING, ttl=None)
+
+        # Invalid TTL
+        with pytest.raises(ValidationError):
+            StateVariable(key="test", value="test", type_name=StateVariableType.STRING, ttl=0)
+
+        with pytest.raises(ValidationError):
+            StateVariable(key="test", value="test", type_name=StateVariableType.STRING, ttl=-1)
+
+    def test_expiration_checking(self):
+        """Test variable expiration."""
+        # Non-expiring variable
+        var = StateVariable(key="test", value="test", type_name=StateVariableType.STRING)
+        assert not var.is_expired
+
+        # Expired variable
+        past_time = datetime.utcnow() - timedelta(seconds=10)
+        expired_var = StateVariable(
+            key="test",
+            value="test",
+            type_name=StateVariableType.STRING,
+            ttl=5,  # 5 seconds
+            updated_at=past_time
+        )
+        assert expired_var.is_expired
+
+        # Not yet expired
+        recent_time = datetime.utcnow() - timedelta(seconds=1)
+        fresh_var = StateVariable(
+            key="test",
+            value="test",
+            type_name=StateVariableType.STRING,
+            ttl=10,
+            updated_at=recent_time
+        )
+        assert not fresh_var.is_expired
+
+    def test_touch_method(self):
+        """Test the touch method for updating timestamps."""
+        var = StateVariable(key="test", value="test", type_name=StateVariableType.STRING)
+        original_version = var.version
+        original_time = var.updated_at
+
+        # Small delay to ensure timestamp difference
+        import time
+        time.sleep(0.01)
+
+        var.touch()
+
+        assert var.version == original_version + 1
+        assert var.updated_at > original_time
+
+
+class TestConversationMessage:
+    """Test ConversationMessage model."""
+
+    def test_basic_message_creation(self):
+        """Test creating basic messages."""
+        message = ConversationMessage(
+            id="msg_123",
+            role=ConversationRole.USER,
+            content="Hello, how are you?",
+            tokens=5
+        )
+
+        assert message.id == "msg_123"
+        assert message.role == ConversationRole.USER
+        assert message.content == "Hello, how are you?"
+        assert message.tokens == 5
+        assert isinstance(message.timestamp, datetime)
+
+    def test_function_message(self):
+        """Test function call message."""
+        message = ConversationMessage(
+            id="msg_func",
+            role=ConversationRole.FUNCTION,
+            content="Function result",
+            function_name="get_weather",
+            function_call={"location": "New York", "units": "celsius"}
+        )
+
+        assert message.role == ConversationRole.FUNCTION
+        assert message.function_name == "get_weather"
+        assert message.function_call["location"] == "New York"
+
+    def test_tool_calls_message(self):
+        """Test message with tool calls."""
+        message = ConversationMessage(
+            id="msg_tool",
+            role=ConversationRole.ASSISTANT,
+            content="I'll help you with that.",
+            tool_calls=[
+                {"tool": "calculator", "operation": "add", "args": [2, 3]},
+                {"tool": "search", "query": "weather today"}
+            ]
+        )
+
+        assert len(message.tool_calls) == 2
+        assert message.tool_calls[0]["tool"] == "calculator"
+        assert message.tool_calls[1]["tool"] == "search"
+
+    def test_threaded_message(self):
+        """Test message with threading."""
+        message = ConversationMessage(
+            id="msg_reply",
+            role=ConversationRole.USER,
+            content="Thanks for the help!",
+            reply_to="msg_assistant",
+            thread_id="thread_123"
+        )
+
+        assert message.reply_to == "msg_assistant"
+        assert message.thread_id == "thread_123"
+
+    def test_content_validation(self):
+        """Test message content validation."""
+        # Valid content
+        ConversationMessage(
+            id="test",
+            role=ConversationRole.USER,
+            content="Normal message"
+        )
+
+        # Too large content
+        large_content = "x" * (1_000_001)  # Over 1MB
+        with pytest.raises(ValidationError) as exc_info:
+            ConversationMessage(
+                id="test",
+                role=ConversationRole.USER,
+                content=large_content
+            )
+        assert "too large" in str(exc_info.value)
+
+    def test_message_id_validation(self):
+        """Test message ID validation."""
+        # Valid IDs
+        ConversationMessage(id="msg_123", role=ConversationRole.USER, content="test")
+        ConversationMessage(id="a", role=ConversationRole.USER, content="test")  # Minimum
+        ConversationMessage(id="x" * 128, role=ConversationRole.USER, content="test")  # Maximum
+
+        # Invalid IDs
+        with pytest.raises(ValidationError):
+            ConversationMessage(id="", role=ConversationRole.USER, content="test")
+
+        with pytest.raises(ValidationError):
+            ConversationMessage(id="x" * 129, role=ConversationRole.USER, content="test")  # Too long
+
+
+class TestConversationState:
+    """Test ConversationState model."""
+
+    def test_basic_conversation_state(self):
+        """Test basic conversation state creation."""
+        state = ConversationState(
+            context_id="conv_123",
+            user_id="user_456",
+            session_id="session_789"
+        )
+
+        assert state.context_id == "conv_123"
+        assert state.user_id == "user_456"
+        assert state.session_id == "session_789"
+        assert len(state.variables) == 0
+        assert len(state.history) == 0
+        assert state.max_history_size == 100
+        assert state.auto_summarize is True
+
+    def test_add_message(self):
+        """Test adding messages to conversation."""
+        state = ConversationState(context_id="test")
+
+        message1 = ConversationMessage(
+            id="msg1",
+            role=ConversationRole.USER,
+            content="Hello"
+        )
+        message2 = ConversationMessage(
+            id="msg2",
+            role=ConversationRole.ASSISTANT,
+            content="Hi there!"
+        )
+
+        state.add_message(message1)
+        state.add_message(message2)
+
+        assert len(state.history) == 2
+        assert state.history[0].id == "msg1"
+        assert state.history[1].id == "msg2"
+        assert state.last_activity > state.created_at
+
+    def test_message_history_limit(self):
+        """Test message history size limiting."""
+        state = ConversationState(context_id="test", max_history_size=3)
+
+        # Add more messages than the limit
+        for i in range(5):
+            message = ConversationMessage(
+                id=f"msg{i}",
+                role=ConversationRole.USER,
+                content=f"Message {i}"
+            )
+            state.add_message(message)
+
+        # Should only keep the last 3 messages (or half when auto-summarizing)
+        assert len(state.history) <= 3
+        assert state.archived_messages > 0
+
+    def test_set_and_get_variable(self):
+        """Test setting and getting state variables."""
+        state = ConversationState(context_id="test")
+
+        # Set variables
+        state.set_variable("user_name", "John", ttl=3600)
+        state.set_variable("user_age", 25)
+        state.set_variable("preferences", {"theme": "dark"})
+
+        # Get variables
+        assert state.get_variable("user_name") == "John"
+        assert state.get_variable("user_age") == 25
+        assert state.get_variable("preferences")["theme"] == "dark"
+        assert state.get_variable("nonexistent", "default") == "default"
+
+        # Check variable objects
+        assert len(state.variables) == 3
+        assert state.variables["user_name"].ttl == 3600
+        assert state.variables["user_age"].ttl is None
+
+    def test_variable_count_limit(self):
+        """Test variable count limiting."""
+        state = ConversationState(context_id="test", max_variable_count=2)
+
+        # Set variables up to limit
+        state.set_variable("var1", "value1")
+        state.set_variable("var2", "value2")
+
+        # Exceeding limit should raise error
+        with pytest.raises(ValueError) as exc_info:
+            state.set_variable("var3", "value3")
+        assert "Maximum variable count" in str(exc_info.value)
+
+        # Updating existing variable should work
+        state.set_variable("var1", "new_value1")
+        assert state.get_variable("var1") == "new_value1"
+
+    def test_delete_variable(self):
+        """Test deleting state variables."""
+        state = ConversationState(context_id="test")
+
+        state.set_variable("test_var", "test_value")
+        assert state.get_variable("test_var") == "test_value"
+
+        # Delete existing variable
+        result = state.delete_variable("test_var")
+        assert result is True
+        assert state.get_variable("test_var") is None
+
+        # Delete non-existent variable
+        result = state.delete_variable("nonexistent")
+        assert result is False
+
+    def test_cleanup_expired_variables(self):
+        """Test cleaning up expired variables."""
+        state = ConversationState(context_id="test")
+
+        # Set variables with different TTLs
+        past_time = datetime.utcnow() - timedelta(seconds=10)
+
+        # Create expired variable manually
+        expired_var = StateVariable(
+            key="expired",
+            value="old_value",
+            type_name=StateVariableType.STRING,
+            ttl=5,
+            updated_at=past_time
+        )
+        state.variables["expired"] = expired_var
+
+        # Create fresh variable
+        state.set_variable("fresh", "new_value", ttl=3600)
+
+        # Cleanup expired variables
+        removed_count = state.cleanup_expired_variables()
+
+        assert removed_count == 1
+        assert "expired" not in state.variables
+        assert "fresh" in state.variables
+
+    def test_summary_stats(self):
+        """Test conversation summary statistics."""
+        state = ConversationState(context_id="test")
+
+        # Add some messages
+        messages = [
+            ConversationMessage(id="1", role=ConversationRole.USER, content="Hello", tokens=2),
+            ConversationMessage(id="2", role=ConversationRole.ASSISTANT, content="Hi!", tokens=1),
+            ConversationMessage(id="3", role=ConversationRole.USER, content="How are you?", tokens=3),
+            ConversationMessage(id="4", role=ConversationRole.ASSISTANT, content="I'm good!", tokens=2)
+        ]
+
+        for msg in messages:
+            state.add_message(msg)
+
+        # Add some tags
+        state.tags = ["greeting", "casual"]
+
+        # Get summary
+        summary = state.get_summary_stats()
+
+        assert summary.total_messages == 4
+        assert summary.user_messages == 2
+        assert summary.assistant_messages == 2
+        assert summary.total_tokens == 8
+        assert summary.first_message_at == messages[0].timestamp
+        assert summary.last_message_at == messages[-1].timestamp
+        assert summary.topics == ["greeting", "casual"]
+
+    def test_context_id_validation(self):
+        """Test context ID validation."""
+        # Valid IDs
+        ConversationState(context_id="conv_123")
+        ConversationState(context_id="a")  # Minimum
+        ConversationState(context_id="x" * 128)  # Maximum
+
+        # Invalid IDs
+        with pytest.raises(ValidationError):
+            ConversationState(context_id="")
+
+        with pytest.raises(ValidationError):
+            ConversationState(context_id="x" * 129)
+
+    def test_limits_validation(self):
+        """Test conversation limits validation."""
+        # Valid limits
+        ConversationState(context_id="test", max_history_size=1, max_variable_count=1)
+        ConversationState(context_id="test", max_history_size=10000, max_variable_count=10000)
+
+        # Invalid limits
+        with pytest.raises(ValidationError):
+            ConversationState(context_id="test", max_history_size=0)
+
+        with pytest.raises(ValidationError):
+            ConversationState(context_id="test", max_variable_count=0)
+
+        with pytest.raises(ValidationError):
+            ConversationState(context_id="test", max_history_size=10001)
+
+
+class TestStateBackendConfig:
+    """Test state backend configuration."""
+
+    def test_memory_backend_config(self):
+        """Test memory backend configuration."""
+        config = StateBackendConfig(
+            type=StateBackendType.MEMORY,
+            max_size=5000,
+            ttl=1800
+        )
+
+        assert config.type == StateBackendType.MEMORY
+        assert config.max_size == 5000
+        assert config.ttl == 1800
+
+    def test_redis_backend_config(self):
+        """Test Redis backend configuration."""
+        config = StateBackendConfig(
+            type=StateBackendType.REDIS,
+            host="localhost",
+            port=6379,
+            database="0",
+            redis_settings={"db": 0, "decode_responses": True}
+        )
+
+        assert config.type == StateBackendType.REDIS
+        assert config.host == "localhost"
+        assert config.port == 6379
+        assert config.redis_settings["db"] == 0
+
+    def test_file_backend_config(self):
+        """Test file backend configuration."""
+        config = StateBackendConfig(
+            type=StateBackendType.FILE,
+            file_path="/var/lib/agentup/state.db",
+            compression=True
+        )
+
+        assert config.type == StateBackendType.FILE
+        assert config.file_path == "/var/lib/agentup/state.db"
+        assert config.compression is True
+
+    def test_database_backend_config(self):
+        """Test database backend configuration."""
+        config = StateBackendConfig(
+            type=StateBackendType.DATABASE,
+            connection_string="postgresql://user:pass@localhost/agentup",
+            table_name="conversation_states",
+            connection_pool_size=20
+        )
+
+        assert config.type == StateBackendType.DATABASE
+        assert "postgresql://" in config.connection_string
+        assert config.table_name == "conversation_states"
+        assert config.connection_pool_size == 20
+
+    def test_backend_validation(self):
+        """Test backend configuration validation."""
+        # Valid values
+        StateBackendConfig(type=StateBackendType.MEMORY, ttl=1, max_size=1)
+        StateBackendConfig(type=StateBackendType.REDIS, port=1)
+        StateBackendConfig(type=StateBackendType.REDIS, port=65535)
+
+        # Invalid values
+        with pytest.raises(ValidationError):
+            StateBackendConfig(type=StateBackendType.MEMORY, ttl=0)
+
+        with pytest.raises(ValidationError):
+            StateBackendConfig(type=StateBackendType.MEMORY, max_size=0)
+
+        with pytest.raises(ValidationError):
+            StateBackendConfig(type=StateBackendType.REDIS, port=0)
+
+        with pytest.raises(ValidationError):
+            StateBackendConfig(type=StateBackendType.REDIS, port=65536)
+
+
+class TestStateOperation:
+    """Test state operation tracking."""
+
+    def test_state_operation_creation(self):
+        """Test creating state operations."""
+        operation = StateOperation(
+            operation_id="op_123",
+            operation_type=StateOperationType.SET,
+            context_id="conv_456",
+            key="user_name",
+            success=True,
+            user_id="user_789"
+        )
+
+        assert operation.operation_id == "op_123"
+        assert operation.operation_type == StateOperationType.SET
+        assert operation.context_id == "conv_456"
+        assert operation.key == "user_name"
+        assert operation.success is True
+        assert operation.user_id == "user_789"
+        assert isinstance(operation.timestamp, datetime)
+
+    def test_failed_operation(self):
+        """Test failed state operation."""
+        operation = StateOperation(
+            operation_id="op_fail",
+            operation_type=StateOperationType.GET,
+            context_id="conv_123",
+            key="missing_key",
+            success=False,
+            error_message="Key not found",
+            duration_ms=5.2
+        )
+
+        assert operation.success is False
+        assert operation.error_message == "Key not found"
+        assert operation.duration_ms == 5.2
+
+
+class TestStateMetrics:
+    """Test state metrics model."""
+
+    def test_state_metrics(self):
+        """Test state metrics creation."""
+        metrics = StateMetrics(
+            total_contexts=150,
+            total_variables=1200,
+            total_messages=5000,
+            avg_variables_per_context=8.0,
+            avg_messages_per_context=33.3,
+            avg_get_latency_ms=2.5,
+            avg_set_latency_ms=3.8,
+            backend_type=StateBackendType.REDIS,
+            backend_health="healthy",
+            measurement_window=timedelta(hours=1)
+        )
+
+        assert metrics.total_contexts == 150
+        assert metrics.avg_variables_per_context == 8.0
+        assert metrics.backend_type == StateBackendType.REDIS
+        assert metrics.backend_health == "healthy"
+        assert metrics.measurement_window == timedelta(hours=1)
+
+
+class TestStateConfig:
+    """Test complete state configuration."""
+
+    def test_default_state_config(self):
+        """Test default state configuration."""
+        backend = StateBackendConfig(type=StateBackendType.MEMORY)
+        config = StateConfig(backend=backend)
+
+        assert config.enabled is True
+        assert config.backend.type == StateBackendType.MEMORY
+        assert config.default_max_history == 100
+        assert config.default_max_variables == 1000
+        assert config.cleanup_enabled is True
+        assert config.cache_enabled is True
+        assert config.metrics_enabled is True
+
+    def test_custom_state_config(self):
+        """Test custom state configuration."""
+        backend = StateBackendConfig(
+            type=StateBackendType.REDIS,
+            host="redis.example.com",
+            port=6379
+        )
+        config = StateConfig(
+            enabled=True,
+            backend=backend,
+            default_max_history=200,
+            default_max_variables=2000,
+            cleanup_interval=600,
+            cache_size=2000,
+            operation_logging=True
+        )
+
+        assert config.backend.type == StateBackendType.REDIS
+        assert config.backend.host == "redis.example.com"
+        assert config.default_max_history == 200
+        assert config.default_max_variables == 2000
+        assert config.cleanup_interval == 600
+        assert config.operation_logging is True
+
+    def test_state_config_validation(self):
+        """Test state configuration validation."""
+        backend = StateBackendConfig(type=StateBackendType.MEMORY)
+
+        # Valid configurations
+        StateConfig(backend=backend, default_max_history=1, cache_size=1)
+
+        # Invalid configurations
+        with pytest.raises(ValidationError):
+            StateConfig(backend=backend, default_max_history=0)
+
+        with pytest.raises(ValidationError):
+            StateConfig(backend=backend, default_max_variables=0)
+
+        with pytest.raises(ValidationError):
+            StateConfig(backend=backend, cache_size=0)
+
+
+class TestModelIntegration:
+    """Test model integration and complex scenarios."""
+
+    def test_full_conversation_workflow(self):
+        """Test a complete conversation workflow."""
+        # Create conversation state
+        state = ConversationState(
+            context_id="full_test",
+            user_id="user123",
+            max_history_size=5
+        )
+
+        # Set initial variables
+        state.set_variable("user_name", "Alice")
+        state.set_variable("language", "en")
+        state.set_variable("theme", "dark")
+
+        # Add conversation messages
+        messages = [
+            ConversationMessage(id="1", role=ConversationRole.USER, content="Hi, I'm Alice"),
+            ConversationMessage(id="2", role=ConversationRole.ASSISTANT, content="Hello Alice! How can I help?"),
+            ConversationMessage(id="3", role=ConversationRole.USER, content="What's the weather like?"),
+            ConversationMessage(id="4", role=ConversationRole.ASSISTANT, content="Let me check that for you."),
+            ConversationMessage(id="5", role=ConversationRole.FUNCTION, content="Sunny, 72°F", function_name="get_weather"),
+            ConversationMessage(id="6", role=ConversationRole.ASSISTANT, content="It's sunny and 72°F today!"),
+        ]
+
+        for msg in messages:
+            state.add_message(msg)
+
+        # Verify state
+        assert len(state.variables) == 3
+        assert state.get_variable("user_name") == "Alice"
+        assert len(state.history) <= 5  # Should respect limit
+
+        # Get summary
+        summary = state.get_summary_stats()
+        assert summary.total_messages >= 3  # Some may be archived
+        # Note: Due to history size limit, some USER messages may have been archived
+        # The total count should still be correct due to our fix
+        assert summary.total_messages == 6  # All 6 messages should be counted (current + archived)
+        assert summary.assistant_messages >= 1
+
+    def test_state_persistence_simulation(self):
+        """Test state persistence-like operations."""
+        # Simulate saving/loading state
+        original_state = ConversationState(
+            context_id="persist_test",
+            user_id="user456"
+        )
+
+        original_state.set_variable("session_start", datetime.utcnow().isoformat())
+        original_state.add_message(ConversationMessage(
+            id="msg1",
+            role=ConversationRole.USER,
+            content="Test message"
+        ))
+
+        # Serialize to dict (simulating persistence)
+        state_dict = original_state.dict()
+
+        # Deserialize from dict (simulating loading)
+        loaded_state = ConversationState(**state_dict)
+
+        assert loaded_state.context_id == original_state.context_id
+        assert loaded_state.user_id == original_state.user_id
+        assert len(loaded_state.variables) == len(original_state.variables)
+        assert len(loaded_state.history) == len(original_state.history)
+
+    def test_variable_type_detection(self):
+        """Test automatic variable type detection."""
+        state = ConversationState(context_id="type_test")
+
+        # Test different value types
+        test_values = [
+            ("string_var", "hello", StateVariableType.STRING),
+            ("int_var", 42, StateVariableType.INTEGER),
+            ("float_var", 3.14, StateVariableType.FLOAT),
+            ("bool_var", True, StateVariableType.BOOLEAN),
+            ("list_var", [1, 2, 3], StateVariableType.LIST),
+            ("dict_var", {"key": "value"}, StateVariableType.DICT),
+            ("bytes_var", b"binary", StateVariableType.BINARY),
+        ]
+
+        for key, value, expected_type in test_values:
+            state.set_variable(key, value)
+            assert state.variables[key].type_name == expected_type
+            assert state.variables[key].value == value

--- a/tests/test_state_models.py
+++ b/tests/test_state_models.py
@@ -1,6 +1,7 @@
 """
 Tests for AgentUp state management models.
 """
+
 from datetime import datetime, timedelta
 
 import pytest
@@ -27,10 +28,7 @@ class TestStateVariable:
     def test_string_state_variable(self):
         """Test string state variable."""
         var = StateVariable[str](
-            key="user_name",
-            value="John Doe",
-            type_name=StateVariableType.STRING,
-            description="User's full name"
+            key="user_name", value="John Doe", type_name=StateVariableType.STRING, description="User's full name"
         )
 
         assert var.key == "user_name"
@@ -45,7 +43,7 @@ class TestStateVariable:
             key="user_age",
             value=25,
             type_name=StateVariableType.INTEGER,
-            ttl=3600  # 1 hour
+            ttl=3600,  # 1 hour
         )
 
         assert var.key == "user_age"
@@ -57,10 +55,7 @@ class TestStateVariable:
         """Test dictionary state variable."""
         config_data = {"theme": "dark", "notifications": True}
         var = StateVariable[dict](
-            key="user_config",
-            value=config_data,
-            type_name=StateVariableType.DICT,
-            tags=["config", "user"]
+            key="user_config", value=config_data, type_name=StateVariableType.DICT, tags=["config", "user"]
         )
 
         assert var.key == "user_config"
@@ -112,18 +107,14 @@ class TestStateVariable:
             value="test",
             type_name=StateVariableType.STRING,
             ttl=5,  # 5 seconds
-            updated_at=past_time
+            updated_at=past_time,
         )
         assert expired_var.is_expired
 
         # Not yet expired
         recent_time = datetime.utcnow() - timedelta(seconds=1)
         fresh_var = StateVariable(
-            key="test",
-            value="test",
-            type_name=StateVariableType.STRING,
-            ttl=10,
-            updated_at=recent_time
+            key="test", value="test", type_name=StateVariableType.STRING, ttl=10, updated_at=recent_time
         )
         assert not fresh_var.is_expired
 
@@ -135,6 +126,7 @@ class TestStateVariable:
 
         # Small delay to ensure timestamp difference
         import time
+
         time.sleep(0.01)
 
         var.touch()
@@ -148,12 +140,7 @@ class TestConversationMessage:
 
     def test_basic_message_creation(self):
         """Test creating basic messages."""
-        message = ConversationMessage(
-            id="msg_123",
-            role=ConversationRole.USER,
-            content="Hello, how are you?",
-            tokens=5
-        )
+        message = ConversationMessage(id="msg_123", role=ConversationRole.USER, content="Hello, how are you?", tokens=5)
 
         assert message.id == "msg_123"
         assert message.role == ConversationRole.USER
@@ -168,7 +155,7 @@ class TestConversationMessage:
             role=ConversationRole.FUNCTION,
             content="Function result",
             function_name="get_weather",
-            function_call={"location": "New York", "units": "celsius"}
+            function_call={"location": "New York", "units": "celsius"},
         )
 
         assert message.role == ConversationRole.FUNCTION
@@ -183,8 +170,8 @@ class TestConversationMessage:
             content="I'll help you with that.",
             tool_calls=[
                 {"tool": "calculator", "operation": "add", "args": [2, 3]},
-                {"tool": "search", "query": "weather today"}
-            ]
+                {"tool": "search", "query": "weather today"},
+            ],
         )
 
         assert len(message.tool_calls) == 2
@@ -198,7 +185,7 @@ class TestConversationMessage:
             role=ConversationRole.USER,
             content="Thanks for the help!",
             reply_to="msg_assistant",
-            thread_id="thread_123"
+            thread_id="thread_123",
         )
 
         assert message.reply_to == "msg_assistant"
@@ -207,20 +194,12 @@ class TestConversationMessage:
     def test_content_validation(self):
         """Test message content validation."""
         # Valid content
-        ConversationMessage(
-            id="test",
-            role=ConversationRole.USER,
-            content="Normal message"
-        )
+        ConversationMessage(id="test", role=ConversationRole.USER, content="Normal message")
 
         # Too large content
         large_content = "x" * (1_000_001)  # Over 1MB
         with pytest.raises(ValidationError) as exc_info:
-            ConversationMessage(
-                id="test",
-                role=ConversationRole.USER,
-                content=large_content
-            )
+            ConversationMessage(id="test", role=ConversationRole.USER, content=large_content)
         assert "too large" in str(exc_info.value)
 
     def test_message_id_validation(self):
@@ -243,11 +222,7 @@ class TestConversationState:
 
     def test_basic_conversation_state(self):
         """Test basic conversation state creation."""
-        state = ConversationState(
-            context_id="conv_123",
-            user_id="user_456",
-            session_id="session_789"
-        )
+        state = ConversationState(context_id="conv_123", user_id="user_456", session_id="session_789")
 
         assert state.context_id == "conv_123"
         assert state.user_id == "user_456"
@@ -261,16 +236,8 @@ class TestConversationState:
         """Test adding messages to conversation."""
         state = ConversationState(context_id="test")
 
-        message1 = ConversationMessage(
-            id="msg1",
-            role=ConversationRole.USER,
-            content="Hello"
-        )
-        message2 = ConversationMessage(
-            id="msg2",
-            role=ConversationRole.ASSISTANT,
-            content="Hi there!"
-        )
+        message1 = ConversationMessage(id="msg1", role=ConversationRole.USER, content="Hello")
+        message2 = ConversationMessage(id="msg2", role=ConversationRole.ASSISTANT, content="Hi there!")
 
         state.add_message(message1)
         state.add_message(message2)
@@ -286,11 +253,7 @@ class TestConversationState:
 
         # Add more messages than the limit
         for i in range(5):
-            message = ConversationMessage(
-                id=f"msg{i}",
-                role=ConversationRole.USER,
-                content=f"Message {i}"
-            )
+            message = ConversationMessage(id=f"msg{i}", role=ConversationRole.USER, content=f"Message {i}")
             state.add_message(message)
 
         # Should only keep the last 3 messages (or half when auto-summarizing)
@@ -359,11 +322,7 @@ class TestConversationState:
 
         # Create expired variable manually
         expired_var = StateVariable(
-            key="expired",
-            value="old_value",
-            type_name=StateVariableType.STRING,
-            ttl=5,
-            updated_at=past_time
+            key="expired", value="old_value", type_name=StateVariableType.STRING, ttl=5, updated_at=past_time
         )
         state.variables["expired"] = expired_var
 
@@ -386,7 +345,7 @@ class TestConversationState:
             ConversationMessage(id="1", role=ConversationRole.USER, content="Hello", tokens=2),
             ConversationMessage(id="2", role=ConversationRole.ASSISTANT, content="Hi!", tokens=1),
             ConversationMessage(id="3", role=ConversationRole.USER, content="How are you?", tokens=3),
-            ConversationMessage(id="4", role=ConversationRole.ASSISTANT, content="I'm good!", tokens=2)
+            ConversationMessage(id="4", role=ConversationRole.ASSISTANT, content="I'm good!", tokens=2),
         ]
 
         for msg in messages:
@@ -442,11 +401,7 @@ class TestStateBackendConfig:
 
     def test_memory_backend_config(self):
         """Test memory backend configuration."""
-        config = StateBackendConfig(
-            type=StateBackendType.MEMORY,
-            max_size=5000,
-            ttl=1800
-        )
+        config = StateBackendConfig(type=StateBackendType.MEMORY, max_size=5000, ttl=1800)
 
         assert config.type == StateBackendType.MEMORY
         assert config.max_size == 5000
@@ -459,7 +414,7 @@ class TestStateBackendConfig:
             host="localhost",
             port=6379,
             database="0",
-            redis_settings={"db": 0, "decode_responses": True}
+            redis_settings={"db": 0, "decode_responses": True},
         )
 
         assert config.type == StateBackendType.REDIS
@@ -469,11 +424,7 @@ class TestStateBackendConfig:
 
     def test_file_backend_config(self):
         """Test file backend configuration."""
-        config = StateBackendConfig(
-            type=StateBackendType.FILE,
-            file_path="/var/lib/agentup/state.db",
-            compression=True
-        )
+        config = StateBackendConfig(type=StateBackendType.FILE, file_path="/var/lib/agentup/state.db", compression=True)
 
         assert config.type == StateBackendType.FILE
         assert config.file_path == "/var/lib/agentup/state.db"
@@ -485,7 +436,7 @@ class TestStateBackendConfig:
             type=StateBackendType.DATABASE,
             connection_string="postgresql://user:pass@localhost/agentup",
             table_name="conversation_states",
-            connection_pool_size=20
+            connection_pool_size=20,
         )
 
         assert config.type == StateBackendType.DATABASE
@@ -525,7 +476,7 @@ class TestStateOperation:
             context_id="conv_456",
             key="user_name",
             success=True,
-            user_id="user_789"
+            user_id="user_789",
         )
 
         assert operation.operation_id == "op_123"
@@ -545,7 +496,7 @@ class TestStateOperation:
             key="missing_key",
             success=False,
             error_message="Key not found",
-            duration_ms=5.2
+            duration_ms=5.2,
         )
 
         assert operation.success is False
@@ -568,7 +519,7 @@ class TestStateMetrics:
             avg_set_latency_ms=3.8,
             backend_type=StateBackendType.REDIS,
             backend_health="healthy",
-            measurement_window=timedelta(hours=1)
+            measurement_window=timedelta(hours=1),
         )
 
         assert metrics.total_contexts == 150
@@ -596,11 +547,7 @@ class TestStateConfig:
 
     def test_custom_state_config(self):
         """Test custom state configuration."""
-        backend = StateBackendConfig(
-            type=StateBackendType.REDIS,
-            host="redis.example.com",
-            port=6379
-        )
+        backend = StateBackendConfig(type=StateBackendType.REDIS, host="redis.example.com", port=6379)
         config = StateConfig(
             enabled=True,
             backend=backend,
@@ -608,7 +555,7 @@ class TestStateConfig:
             default_max_variables=2000,
             cleanup_interval=600,
             cache_size=2000,
-            operation_logging=True
+            operation_logging=True,
         )
 
         assert config.backend.type == StateBackendType.REDIS
@@ -642,11 +589,7 @@ class TestModelIntegration:
     def test_full_conversation_workflow(self):
         """Test a complete conversation workflow."""
         # Create conversation state
-        state = ConversationState(
-            context_id="full_test",
-            user_id="user123",
-            max_history_size=5
-        )
+        state = ConversationState(context_id="full_test", user_id="user123", max_history_size=5)
 
         # Set initial variables
         state.set_variable("user_name", "Alice")
@@ -659,7 +602,9 @@ class TestModelIntegration:
             ConversationMessage(id="2", role=ConversationRole.ASSISTANT, content="Hello Alice! How can I help?"),
             ConversationMessage(id="3", role=ConversationRole.USER, content="What's the weather like?"),
             ConversationMessage(id="4", role=ConversationRole.ASSISTANT, content="Let me check that for you."),
-            ConversationMessage(id="5", role=ConversationRole.FUNCTION, content="Sunny, 72°F", function_name="get_weather"),
+            ConversationMessage(
+                id="5", role=ConversationRole.FUNCTION, content="Sunny, 72°F", function_name="get_weather"
+            ),
             ConversationMessage(id="6", role=ConversationRole.ASSISTANT, content="It's sunny and 72°F today!"),
         ]
 
@@ -682,17 +627,10 @@ class TestModelIntegration:
     def test_state_persistence_simulation(self):
         """Test state persistence-like operations."""
         # Simulate saving/loading state
-        original_state = ConversationState(
-            context_id="persist_test",
-            user_id="user456"
-        )
+        original_state = ConversationState(context_id="persist_test", user_id="user456")
 
         original_state.set_variable("session_start", datetime.utcnow().isoformat())
-        original_state.add_message(ConversationMessage(
-            id="msg1",
-            role=ConversationRole.USER,
-            content="Test message"
-        ))
+        original_state.add_message(ConversationMessage(id="msg1", role=ConversationRole.USER, content="Test message"))
 
         # Serialize to dict (simulating persistence)
         state_dict = original_state.dict()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,194 @@
+"""
+Tests for AgentUp type definitions.
+"""
+import pytest  # noqa: F401
+
+from src.agent.types import (
+    AuthScheme,
+    ConfigDict,
+    ContentType,
+    Headers,
+    HttpMethod,
+    IPAddress,
+    MetadataDict,
+    QueryParams,
+    ScopeName,
+    UserId,
+)
+
+
+class TestJsonValue:
+    """Test JsonValue type definition."""
+
+    def test_valid_json_values(self):
+        """Test valid JSON values."""
+        # Primitive types
+        assert isinstance("string", str)
+        assert isinstance(42, int)
+        assert isinstance(3.14, float)
+        assert isinstance(True, bool)
+        assert None is None
+
+        # # Complex types
+        # simple_dict = {"key": "value", "number": 42}
+        # simple_list = ["item1", "item2", 42, True]
+
+        # These would be valid JsonValue types
+        nested_dict = {
+            "string": "value",
+            "number": 42,
+            "boolean": True,
+            "null": None,
+            "list": [1, 2, 3],
+            "dict": {"nested": "value"}
+        }
+
+        assert isinstance(nested_dict["string"], str)
+        assert isinstance(nested_dict["number"], int)
+        assert isinstance(nested_dict["boolean"], bool)
+        assert nested_dict["null"] is None
+        assert isinstance(nested_dict["list"], list)
+        assert isinstance(nested_dict["dict"], dict)
+
+
+class TestTypeAliases:
+    """Test type aliases."""
+
+    def test_user_id_type(self):
+        """Test UserId type alias."""
+        user_id: UserId = "user123"
+        assert isinstance(user_id, str)
+        assert user_id == "user123"
+
+    def test_scope_name_type(self):
+        """Test ScopeName type alias."""
+        scope: ScopeName = "read:api"
+        assert isinstance(scope, str)
+        assert scope == "read:api"
+
+    def test_ip_address_type(self):
+        """Test IPAddress type alias."""
+        ip: IPAddress = "192.168.1.1"
+        assert isinstance(ip, str)
+        assert ip == "192.168.1.1"
+
+    def test_headers_type(self):
+        """Test Headers type."""
+        headers: Headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer token123"
+        }
+        assert isinstance(headers, dict)
+        assert headers["Content-Type"] == "application/json"
+
+    def test_query_params_type(self):
+        """Test QueryParams type."""
+        params: QueryParams = {
+            "single": "value",
+            "multiple": ["value1", "value2"]
+        }
+        assert isinstance(params, dict)
+        assert params["single"] == "value"
+        assert isinstance(params["multiple"], list)
+
+    def test_config_dict_type(self):
+        """Test ConfigDict type."""
+        config: ConfigDict = {
+            "string_setting": "value",
+            "number_setting": 42,
+            "boolean_setting": True,
+            "nested_setting": {"key": "value"}
+        }
+        assert isinstance(config, dict)
+        assert config["string_setting"] == "value"
+        assert config["number_setting"] == 42
+
+    def test_metadata_dict_type(self):
+        """Test MetadataDict type."""
+        metadata: MetadataDict = {
+            "version": "1.0.0",
+            "author": "AgentUp",
+            "description": "Test metadata"
+        }
+        assert isinstance(metadata, dict)
+        assert all(isinstance(v, str) for v in metadata.values())
+
+
+class TestConstants:
+    """Test constant classes."""
+
+    def test_http_method_constants(self):
+        """Test HttpMethod constants."""
+        assert HttpMethod.GET == "GET"
+        assert HttpMethod.POST == "POST"
+        assert HttpMethod.PUT == "PUT"
+        assert HttpMethod.DELETE == "DELETE"
+        assert HttpMethod.PATCH == "PATCH"
+        assert HttpMethod.HEAD == "HEAD"
+        assert HttpMethod.OPTIONS == "OPTIONS"
+
+    def test_content_type_constants(self):
+        """Test ContentType constants."""
+        assert ContentType.JSON == "application/json"
+        assert ContentType.XML == "application/xml"
+        assert ContentType.TEXT == "text/plain"
+        assert ContentType.HTML == "text/html"
+        assert ContentType.FORM == "application/x-www-form-urlencoded"
+        assert ContentType.MULTIPART == "multipart/form-data"
+        assert ContentType.BINARY == "application/octet-stream"
+
+    def test_auth_scheme_constants(self):
+        """Test AuthScheme constants."""
+        assert AuthScheme.BEARER == "Bearer"
+        assert AuthScheme.BASIC == "Basic"
+        assert AuthScheme.API_KEY == "ApiKey"
+        assert AuthScheme.OAUTH2 == "OAuth2"
+
+
+class TestTypeUsage:
+    """Test practical usage of types."""
+
+    def test_function_with_typed_parameters(self):
+        """Test function using typed parameters."""
+        def process_request(
+            user_id: UserId,
+            headers: Headers,
+            params: QueryParams
+        ) -> ConfigDict:
+            return {
+                "user": user_id,
+                "content_type": headers.get("Content-Type"),
+                "param_count": len(params)
+            }
+
+        result = process_request(
+            user_id="user123",
+            headers={"Content-Type": "application/json"},
+            params={"query": "test"}
+        )
+
+        assert result["user"] == "user123"
+        assert result["content_type"] == "application/json"
+        assert result["param_count"] == 1
+
+    def test_nested_json_structure(self):
+        """Test nested JSON-like structure."""
+        complex_config: ConfigDict = {
+            "database": {
+                "host": "localhost",
+                "port": 5432,
+                "credentials": {
+                    "username": "admin",
+                    "password": "secret"
+                }
+            },
+            "features": ["auth", "logging", "monitoring"],
+            "debug": True,
+            "version": "1.0.0"
+        }
+
+        assert isinstance(complex_config["database"], dict)
+        assert isinstance(complex_config["features"], list)
+        assert isinstance(complex_config["debug"], bool)
+        assert complex_config["database"]["port"] == 5432
+        assert "auth" in complex_config["features"]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 """
 Tests for AgentUp type definitions.
 """
+
 import pytest  # noqa: F401
 
 from src.agent.types import (
@@ -40,7 +41,7 @@ class TestJsonValue:
             "boolean": True,
             "null": None,
             "list": [1, 2, 3],
-            "dict": {"nested": "value"}
+            "dict": {"nested": "value"},
         }
 
         assert isinstance(nested_dict["string"], str)
@@ -74,19 +75,13 @@ class TestTypeAliases:
 
     def test_headers_type(self):
         """Test Headers type."""
-        headers: Headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer token123"
-        }
+        headers: Headers = {"Content-Type": "application/json", "Authorization": "Bearer token123"}
         assert isinstance(headers, dict)
         assert headers["Content-Type"] == "application/json"
 
     def test_query_params_type(self):
         """Test QueryParams type."""
-        params: QueryParams = {
-            "single": "value",
-            "multiple": ["value1", "value2"]
-        }
+        params: QueryParams = {"single": "value", "multiple": ["value1", "value2"]}
         assert isinstance(params, dict)
         assert params["single"] == "value"
         assert isinstance(params["multiple"], list)
@@ -97,7 +92,7 @@ class TestTypeAliases:
             "string_setting": "value",
             "number_setting": 42,
             "boolean_setting": True,
-            "nested_setting": {"key": "value"}
+            "nested_setting": {"key": "value"},
         }
         assert isinstance(config, dict)
         assert config["string_setting"] == "value"
@@ -105,11 +100,7 @@ class TestTypeAliases:
 
     def test_metadata_dict_type(self):
         """Test MetadataDict type."""
-        metadata: MetadataDict = {
-            "version": "1.0.0",
-            "author": "AgentUp",
-            "description": "Test metadata"
-        }
+        metadata: MetadataDict = {"version": "1.0.0", "author": "AgentUp", "description": "Test metadata"}
         assert isinstance(metadata, dict)
         assert all(isinstance(v, str) for v in metadata.values())
 
@@ -150,21 +141,12 @@ class TestTypeUsage:
 
     def test_function_with_typed_parameters(self):
         """Test function using typed parameters."""
-        def process_request(
-            user_id: UserId,
-            headers: Headers,
-            params: QueryParams
-        ) -> ConfigDict:
-            return {
-                "user": user_id,
-                "content_type": headers.get("Content-Type"),
-                "param_count": len(params)
-            }
+
+        def process_request(user_id: UserId, headers: Headers, params: QueryParams) -> ConfigDict:
+            return {"user": user_id, "content_type": headers.get("Content-Type"), "param_count": len(params)}
 
         result = process_request(
-            user_id="user123",
-            headers={"Content-Type": "application/json"},
-            params={"query": "test"}
+            user_id="user123", headers={"Content-Type": "application/json"}, params={"query": "test"}
         )
 
         assert result["user"] == "user123"
@@ -174,17 +156,10 @@ class TestTypeUsage:
     def test_nested_json_structure(self):
         """Test nested JSON-like structure."""
         complex_config: ConfigDict = {
-            "database": {
-                "host": "localhost",
-                "port": 5432,
-                "credentials": {
-                    "username": "admin",
-                    "password": "secret"
-                }
-            },
+            "database": {"host": "localhost", "port": 5432, "credentials": {"username": "admin", "password": "secret"}},
             "features": ["auth", "logging", "monitoring"],
             "debug": True,
-            "version": "1.0.0"
+            "version": "1.0.0",
         }
 
         assert isinstance(complex_config["database"], dict)

--- a/tests/test_validation_framework.py
+++ b/tests/test_validation_framework.py
@@ -1,0 +1,572 @@
+"""
+Tests for the validation framework.
+"""
+import pytest  # noqa: F401
+from pydantic import BaseModel, Field
+
+from src.agent.utils.validation import (
+    BaseValidator,
+    BusinessRuleValidator,
+    CompositeValidator,
+    ConditionalValidator,
+    CrossFieldValidator,
+    FieldValidator,
+    PerformanceValidator,
+    ValidationResult,
+    validate_email,
+    validate_url,
+    validate_version,
+)
+
+
+# Test models for validation
+class SampleModel(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    age: int = Field(..., ge=0, le=120)
+    email: str
+    website: str | None = None
+
+
+class ComplexModel(BaseModel):
+    title: str
+    items: list[str]
+    metadata: dict[str, str]
+    settings: dict[str, int]
+
+
+class TestValidationResult:
+    """Test ValidationResult model."""
+
+    def test_valid_result(self):
+        """Test creating a valid result."""
+        result = ValidationResult(valid=True)
+
+        assert result.valid is True
+        assert len(result.errors) == 0
+        assert len(result.warnings) == 0
+        assert len(result.suggestions) == 0
+        assert not result.has_errors
+        assert not result.has_warnings
+        assert result.summary == "Validation passed"
+
+    def test_result_with_errors(self):
+        """Test result with validation errors."""
+        result = ValidationResult(valid=False)
+        result.add_error("Name is required")
+        result.add_error("Age must be positive", "age")
+
+        assert result.valid is False
+        assert len(result.errors) == 2
+        assert result.has_errors
+        assert "Name is required" in result.errors
+        assert "age" in result.field_errors
+        assert "Age must be positive" in result.field_errors["age"]
+
+    def test_result_with_warnings_and_suggestions(self):
+        """Test result with warnings and suggestions."""
+        result = ValidationResult(valid=True)
+        result.add_warning("Email format could be improved")
+        result.add_suggestion("Consider adding a description field")
+
+        assert result.valid is True
+        assert result.has_warnings
+        assert len(result.warnings) == 1
+        assert len(result.suggestions) == 1
+        assert "1 warnings" in result.summary
+        assert "1 suggestions" in result.summary
+
+    def test_merge_results(self):
+        """Test merging validation results."""
+        result1 = ValidationResult(valid=True)
+        result1.add_warning("Warning 1")
+        result1.add_suggestion("Suggestion 1")
+
+        result2 = ValidationResult(valid=False)
+        result2.add_error("Error 1")
+        result2.add_error("Field error", "field1")
+
+        result1.merge(result2)
+
+        assert result1.valid is False  # Should be False after merge
+        assert len(result1.errors) == 2  # Both "Error 1" and "Field error" are added to errors list
+        assert len(result1.warnings) == 1
+        assert len(result1.suggestions) == 1
+        assert "field1" in result1.field_errors
+
+
+class TestBaseValidator:
+    """Test base validator functionality."""
+
+    class SimpleValidator(BaseValidator[SampleModel]):
+        def validate(self, model: SampleModel) -> ValidationResult:
+            result = ValidationResult(valid=True)
+            if model.age < 18:
+                result.add_warning("User is under 18")
+            if model.website and not model.website.startswith("https://"):
+                result.add_suggestion("Consider using HTTPS")
+            return result
+
+    def test_dict_validation(self):
+        """Test validating dictionary data."""
+        validator = self.SimpleValidator(SampleModel)
+
+        # Valid data
+        result = validator.validate_dict({
+            "name": "John",
+            "age": 25,
+            "email": "john@example.com"
+        })
+        assert result.valid is True
+
+        # Invalid data (Pydantic validation)
+        result = validator.validate_dict({
+            "name": "",  # Too short
+            "age": -5,   # Negative age
+            "email": "john@example.com"
+        })
+        assert result.valid is False
+        assert len(result.errors) >= 2
+
+    def test_json_validation(self):
+        """Test validating JSON data."""
+        validator = self.SimpleValidator(SampleModel)
+
+        # Valid JSON
+        json_data = '{"name": "Jane", "age": 30, "email": "jane@example.com"}'
+        result = validator.validate_json(json_data)
+        assert result.valid is True
+
+        # Invalid JSON
+        result = validator.validate_json('{"name": "Jane", "age":}')  # Malformed
+        assert result.valid is False
+        assert "Invalid JSON" in result.errors[0]
+
+    def test_custom_validation_logic(self):
+        """Test custom validation logic."""
+        validator = self.SimpleValidator(SampleModel)
+
+        # Test warning for young user
+        model = SampleModel(name="Teen", age=16, email="teen@example.com")
+        result = validator.validate(model)
+        assert result.valid is True
+        assert "under 18" in result.warnings[0]
+
+        # Test HTTPS suggestion
+        model = SampleModel(
+            name="User",
+            age=25,
+            email="user@example.com",
+            website="http://example.com"
+        )
+        result = validator.validate(model)
+        assert result.valid is True
+        assert "HTTPS" in result.suggestions[0]
+
+
+class TestCompositeValidator:
+    """Test composite validator."""
+
+    class AgeValidator(BaseValidator[SampleModel]):
+        def validate(self, model: SampleModel) -> ValidationResult:
+            result = ValidationResult(valid=True)
+            if model.age < 0:
+                result.add_error("Age cannot be negative")
+            elif model.age > 150:
+                result.add_error("Age seems unrealistic")
+            return result
+
+    class EmailValidator(BaseValidator[SampleModel]):
+        def validate(self, model: SampleModel) -> ValidationResult:
+            result = ValidationResult(valid=True)
+            if "@" not in model.email:
+                result.add_error("Email must contain @", "email")
+            return result
+
+    def test_composite_validation(self):
+        """Test running multiple validators."""
+        age_validator = self.AgeValidator(SampleModel)
+        email_validator = self.EmailValidator(SampleModel)
+        composite = CompositeValidator(SampleModel, [age_validator, email_validator])
+
+        # Test with data that fails both validations using validate_dict
+        invalid_data = {"name": "Test", "age": -5, "email": "invalid"}
+        result = composite.validate_dict(invalid_data)
+
+        assert result.valid is False
+        # Pydantic validation adds its own errors, so we just check that validation failed
+        assert len(result.errors) >= 1
+        # Check that the validation failed (custom validators may not run if Pydantic fails first)
+        assert any("age" in error.lower() or "negative" in error.lower() for error in result.errors)
+
+    def test_composite_with_valid_model(self):
+        """Test composite validator with valid model."""
+        age_validator = self.AgeValidator(SampleModel)
+        email_validator = self.EmailValidator(SampleModel)
+        composite = CompositeValidator(SampleModel, [age_validator, email_validator])
+
+        model = SampleModel(name="Valid", age=25, email="valid@example.com")
+        result = composite.validate(model)
+
+        assert result.valid is True
+        assert len(result.errors) == 0
+
+
+class TestConditionalValidator:
+    """Test conditional validator."""
+
+    class WebsiteValidator(BaseValidator[SampleModel]):
+        def validate(self, model: SampleModel) -> ValidationResult:
+            result = ValidationResult(valid=True)
+            if model.website and not model.website.startswith("http"):
+                result.add_error("Website must start with http", "website")
+            return result
+
+    def test_conditional_validation(self):
+        """Test conditional validation execution."""
+        website_validator = self.WebsiteValidator(SampleModel)
+
+        # Only validate if website is provided
+        conditional = ConditionalValidator(
+            SampleModel,
+            condition=lambda m: m.website is not None,
+            validator=website_validator,
+            skip_message="Website validation skipped"
+        )
+
+        # Model without website - should skip validation
+        model1 = SampleModel(name="User1", age=25, email="user1@example.com")
+        result1 = conditional.validate(model1)
+        assert result1.valid is True
+        assert "skipped" in result1.suggestions[0]
+
+        # Model with invalid website - should run validation
+        model2 = SampleModel(
+            name="User2",
+            age=25,
+            email="user2@example.com",
+            website="invalid-url"
+        )
+        result2 = conditional.validate(model2)
+        assert result2.valid is False
+        assert "must start with http" in result2.errors[0]
+
+
+class TestFieldValidator:
+    """Test field-specific validator."""
+
+    def test_field_validation(self):
+        """Test validating specific fields."""
+        validator = FieldValidator(SampleModel)
+
+        # Add field validators
+        validator.add_field_validator(
+            "name",
+            lambda value: "Name cannot be 'admin'" if value.lower() == "admin" else None
+        )
+        validator.add_field_validator(
+            "age",
+            lambda value: "Age should be realistic" if value > 100 else None
+        )
+
+        # Test field validation with data that passes Pydantic but fails custom validation
+        model = SampleModel(name="admin", age=90, email="admin@example.com")  # age=90 is valid for Pydantic
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert len(result.field_errors) >= 1
+        assert "admin" in result.field_errors["name"][0]
+
+    def test_field_validator_exception(self):
+        """Test field validator exception handling."""
+        validator = FieldValidator(SampleModel)
+
+        # Add validator that raises exception
+        validator.add_field_validator(
+            "name",
+            lambda value: 1 / 0  # Will raise ZeroDivisionError
+        )
+
+        model = SampleModel(name="Test", age=25, email="test@example.com")
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert "Field validator error" in result.field_errors["name"][0]
+
+
+class TestBusinessRuleValidator:
+    """Test business rule validator."""
+
+    def test_business_rules(self):
+        """Test business rule validation."""
+        validator = BusinessRuleValidator(SampleModel)
+
+        # Add business rules
+        validator.add_rule(
+            lambda model: model.age >= 18 if model.email.endswith("@company.com") else True,
+            "Company email users must be 18 or older"
+        )
+        validator.add_rule(
+            lambda model: len(model.name) >= 3,
+            "Name must be at least 3 characters"
+        )
+
+        # Test failing business rule
+        model = SampleModel(name="Al", age=16, email="al@company.com")
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert len(result.errors) == 2
+        assert "18 or older" in result.errors[0]
+        assert "3 characters" in result.errors[1]
+
+    def test_business_rule_exception(self):
+        """Test business rule exception handling."""
+        validator = BusinessRuleValidator(SampleModel)
+
+        # Add rule that raises exception
+        validator.add_rule(lambda model: 1 / 0, "This will fail")
+
+        model = SampleModel(name="Test", age=25, email="test@example.com")
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert "Business rule error" in result.errors[0]
+
+
+class TestCrossFieldValidator:
+    """Test cross-field validator."""
+
+    def test_cross_field_constraints(self):
+        """Test cross-field validation."""
+        validator = CrossFieldValidator(SampleModel)
+
+        # Add cross-field constraints
+        validator.add_constraint(
+            ["name", "email"],
+            lambda name, email: name.lower() in email.lower(),
+            "Name should appear in email address"
+        )
+        validator.add_constraint(
+            ["age", "website"],
+            lambda age, website: website is not None if age >= 18 else True,
+            "Adults should have a website"
+        )
+
+        # Test failing constraints
+        model = SampleModel(
+            name="John",
+            age=25,
+            email="jane@example.com"  # Name not in email
+            # No website for adult
+        )
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert len(result.errors) == 2
+        assert "appear in email" in result.errors[0]
+        assert "should have a website" in result.errors[1]
+
+    def test_cross_field_exception(self):
+        """Test cross-field constraint exception handling."""
+        validator = CrossFieldValidator(SampleModel)
+
+        # Add constraint that raises exception
+        validator.add_constraint(
+            ["name", "age"],
+            lambda name, age: 1 / 0,
+            "This will fail"
+        )
+
+        model = SampleModel(name="Test", age=25, email="test@example.com")
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert "Cross-field constraint error" in result.errors[0]
+
+
+class TestPerformanceValidator:
+    """Test performance validator."""
+
+    def test_size_limits(self):
+        """Test size limit validation."""
+        validator = PerformanceValidator(ComplexModel)
+
+        # Set size limits
+        validator.set_size_limit("title", 10)
+        validator.set_size_limit("items", 3)
+        validator.set_size_limit("metadata", 2)
+
+        # Test model exceeding limits
+        model = ComplexModel(
+            title="This title is too long",  # > 10 chars
+            items=["a", "b", "c", "d"],      # > 3 items
+            metadata={"a": "1", "b": "2", "c": "3"},  # > 2 items
+            settings={"x": 1}
+        )
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert len(result.errors) == 3
+        assert any("title" in error for error in result.errors)
+        assert any("items" in error for error in result.errors)
+        assert any("metadata" in error for error in result.errors)
+
+    def test_complexity_limits(self):
+        """Test complexity limit validation."""
+        validator = PerformanceValidator(ComplexModel)
+
+        # Set complexity limits
+        validator.set_complexity_limit("metadata", 5)
+
+        # Test structure with many metadata entries (flat but high count for complexity)
+        large_metadata = {f"key_{i}": f"value_{i}" for i in range(10)}  # More than limit of 5
+        model = ComplexModel(
+            title="Test",
+            items=["a"],
+            metadata=large_metadata,  # High complexity due to size
+            settings={"x": 1}
+        )
+        result = validator.validate(model)
+
+        assert result.valid is False
+        assert "complexity" in result.errors[0]
+
+
+class TestUtilityValidators:
+    """Test utility validation functions."""
+
+    def test_url_validation(self):
+        """Test URL validation utility."""
+        # Valid URLs
+        assert validate_url("https://example.com") is None
+        assert validate_url("http://localhost:8080") is None
+        assert validate_url("https://api.example.com/v1/endpoint") is None
+
+        # Invalid URLs
+        assert validate_url("") is not None
+        assert validate_url("not-a-url") is not None
+        assert validate_url("ftp://example.com") is not None
+        assert validate_url("https://") is not None
+
+    def test_email_validation(self):
+        """Test email validation utility."""
+        # Valid emails
+        assert validate_email("user@example.com") is None
+        assert validate_email("test.email+tag@domain.co.uk") is None
+        assert validate_email("user123@test-domain.org") is None
+
+        # Invalid emails
+        assert validate_email("") is not None
+        assert validate_email("invalid") is not None
+        assert validate_email("user@") is not None
+        assert validate_email("@domain.com") is not None
+        assert validate_email("user@domain") is not None
+
+    def test_version_validation(self):
+        """Test semantic version validation utility."""
+        # Valid versions
+        assert validate_version("1.0.0") is None
+        assert validate_version("10.20.30") is None
+        assert validate_version("1.0.0-alpha") is None
+        assert validate_version("1.0.0-beta.1") is None
+        assert validate_version("1.0.0+build.123") is None
+
+        # Invalid versions
+        assert validate_version("") is not None
+        assert validate_version("1.0") is not None
+        assert validate_version("v1.0.0") is not None
+        assert validate_version("1.0.0.0") is not None
+        assert validate_version("1.0.0-") is not None
+
+
+class TestValidationIntegration:
+    """Test validation framework integration."""
+
+    def test_comprehensive_validation(self):
+        """Test comprehensive model validation."""
+        # Create multiple validators
+        field_validator = FieldValidator(SampleModel)
+        field_validator.add_field_validator(
+            "name",
+            lambda v: "Name too generic" if v.lower() in ["user", "admin"] else None
+        )
+
+        business_validator = BusinessRuleValidator(SampleModel)
+        business_validator.add_rule(
+            lambda m: m.age >= 13,
+            "Must be at least 13 years old"
+        )
+
+        cross_field_validator = CrossFieldValidator(SampleModel)
+        cross_field_validator.add_constraint(
+            ["name", "age"],
+            lambda name, age: len(name) >= 3 if age >= 18 else True,
+            "Adults must have full names"
+        )
+
+        # Combine all validators
+        composite = CompositeValidator(SampleModel, [
+            field_validator,
+            business_validator,
+            cross_field_validator
+        ])
+
+        # Test model that fails business rule validation
+        model = SampleModel(name="Al", age=12, email="al@example.com")
+        result = composite.validate(model)
+
+        assert result.valid is False
+        assert len(result.errors) >= 1  # Business rule should fail (age < 13)
+
+    def test_validation_with_pydantic_errors(self):
+        """Test validation combined with Pydantic validation errors."""
+        validator = BusinessRuleValidator(SampleModel)
+        validator.add_rule(
+            lambda m: m.age != 42,
+            "Age cannot be 42"
+        )
+
+        # Test with both Pydantic and custom validation errors
+        invalid_data = {
+            "name": "",      # Pydantic validation error
+            "age": 42,       # Custom validation error
+            "email": "valid@example.com"
+        }
+
+        result = validator.validate_dict(invalid_data)
+
+        assert result.valid is False
+        # Should have both Pydantic and custom errors
+        all_errors = result.errors + [e for field_errors in result.field_errors.values() for e in field_errors]
+        assert len(all_errors) >= 2
+
+    def test_performance_with_large_models(self):
+        """Test validation performance with larger models."""
+        # Create a model with many fields
+        class LargeModel(BaseModel):
+            field1: str = "value1"
+            field2: str = "value2"
+            field3: str = "value3"
+            field4: str = "value4"
+            field5: str = "value5"
+            large_list: list[str] = Field(default_factory=list)
+            large_dict: dict[str, str] = Field(default_factory=dict)
+
+        # Create comprehensive validator
+        validator = PerformanceValidator(LargeModel)
+        validator.set_size_limit("large_list", 1000)
+        validator.set_size_limit("large_dict", 500)
+
+        # Test with large data
+        model = LargeModel(
+            large_list=["item"] * 100,    # Within limit
+            large_dict={f"key{i}": f"value{i}" for i in range(50)}  # Within limit
+        )
+
+        result = validator.validate(model)
+        assert result.valid is True
+
+        # Test exceeding limits
+        model.large_list = ["item"] * 1001
+        result = validator.validate(model)
+        assert result.valid is False


### PR DESCRIPTION
Modernize Python typing and fix Pydantic v2 compatibility

As part of the work outlined in #97 here is the first lump of refactors
migrating to models and specific types, reducing the Any count.

In this PR:

Remove quoted type annotations using `from __future__ import annotations`
Replace typing.Dict/List with built-in dict/list types in touched code
Update all Pydantic validators from v1 to v2 syntax:
- @validator → @field_validator with @classmethod
- @root_validator → @model_validator(mode='after')
- .json()/.parse_raw() → .model_dump_json()/.model_validate_json()
- .dict() → .model_dump()

Fix type annotation issues in core modules:
- src/agent/types.py: Use built-in dict/list, fix Union types
- src/agent/state/context.py: Add future annotations for forward refs
- src/agent/config/models.py: Add future annotations
- src/agent/security/model.py: Remove quoted return types

Improve validation:
- Fix APIKeyData validation to require character diversity
- Update OAuth2Config to require jwks_url for JWT validation
- Fix SecurityConfig error message assertions for Pydantic v2
- Improve state management message counting with archived messages
- Fix AuthContext serialization for sets of complex objects
- Update validation framework tests for Pydantic v2 behavior

Clean up test warnings and improve reliability:
- Rename TestModel → SampleModel to avoid pytest conflicts
- Use realistic test data that passes Pydantic validation
- Account for validation ordering in custom validators
