### PR TITLE
Configuration Structure Mismatch and Client Registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,7 @@ src/agent/
 ## Development Guidelines
 
 - **Pydantic Handling**:
-  - ALWAYS USE PYDANTIC NATIVE METHODS, NEVER USE .get dict[x,x]
-  - USE PYDANTIC!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! STOP USING .get when we have MODELS!
+  - ALWAYS USE PYDANTIC MODELS over .get style dict
 
 ## Task Completion Workflow
 
@@ -144,14 +143,40 @@ After making code changes, always run:
 
 Tests are organized with pytest markers:
 - `unit`: Fast tests without external dependencies
-- `integration`: Tests with external services
-- `e2e`: End-to-end system tests
-- `performance`: Load and performance tests
-- `security`: Security-focused tests
-- `mcp`: Model Context Protocol tests
-- `a2a`: Agent-to-Agent protocol compliance tests
+
+Run `make test-unit`
 
 Run specific test categories: `uv run pytest -m "unit and not slow"`
+
+## Calling the main endpoint
+
+AgentUp has a single A2A JSON-RPC endoint that should be used to test or validate fixes against an Agent:
+
+```
+```
+```
+curl -s -X POST http://localhost:8000/ \
+```
+      -H "Content-Type: application/json" \
+      -H "X-API-Key: admin-key-123" \
+      -d '{
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "params": {
+          "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": "delete a folder called test"}],
+            "message_id": "msg-001",
+            "kind": "message"
+          }
+        },
+        "id": "req-001"
+      }'
+```
+```
+```
+
+```
 
 ## Configuration Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,6 @@ Run specific test categories: `uv run pytest -m "unit and not slow"`
 AgentUp has a single A2A JSON-RPC endoint that should be used to test or validate fixes against an Agent:
 
 ```
-```
-```
 curl -s -X POST http://localhost:8000/ \
 ```
       -H "Content-Type: application/json" \
@@ -173,10 +171,7 @@ curl -s -X POST http://localhost:8000/ \
         "id": "req-001"
       }'
 ```
-```
-```
 
-```
 
 ## Configuration Structure
 

--- a/docs/mcp/mcp-integration.md
+++ b/docs/mcp/mcp-integration.md
@@ -1,8 +1,5 @@
 # Model Context Protocol (MCP) Integration
 
-!!! warning
-    Development is moving fast, and this document may not reflect the latest changes. Once updated, we will remove this warning.
-
 AgentUp provides comprehensive support for the Model Context Protocol (MCP), enabling seamless integration
 with MCP-compliant tools and servers. This allows your agents to leverage external tools and services through a standardized protocol.
 
@@ -50,37 +47,116 @@ mcp:
   servers:
     - name: "filesystem"
       type: "stdio"
-      command: "uvx"
-      args: ["mcp-server-filesystem", "/workspace"]
+      command: "python"              # Can use python, uvx, npx, or any executable
+      args: ["/path/to/mcp_server.py"] # Path to your MCP server script
       env:
-        WORKSPACE_ROOT: "/workspace"
-      working_dir: "/project"          # Optional: Set working directory for the server process
-      # Map MCP tools to AgentUp security scopes
+        DEBUG: "1"                   # Optional environment variables
+      working_dir: "/tmp"            # Optional: Set working directory for the server process
+      
+      # REQUIRED: Map MCP tools to AgentUp security scopes
+      # Tools are automatically prefixed with server name (e.g., "filesystem:read_file")
       tool_scopes:
+        "filesystem:read_file": ["files:read"]
+        "filesystem:write_file": ["files:write"]
+        "filesystem:list_directory": ["files:read"]
+        # Also include unprefixed names for compatibility
         read_file: ["files:read"]
         write_file: ["files:write"]
         list_directory: ["files:read"]
-        delete_file: ["files:write", "files:delete"]
 ```
 
-### Tool Filtering
+### Creating a Python MCP Server
 
-You can control which MCP tools are available from a server using `allowed_tools` and `blocked_tools`:
+Here's a simple example of a Python-based MCP filesystem server:
+
+```python
+#!/usr/bin/env python3
+"""Simple MCP Filesystem Server"""
+
+import asyncio
+from pathlib import Path
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+# Create MCP server instance
+server = Server("filesystem-server")
+WORKSPACE_DIR = Path("/workspace")
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="read_file",
+            description="Read contents of a file",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path to read"}
+                },
+                "required": ["path"]
+            }
+        ),
+        Tool(
+            name="write_file", 
+            description="Write contents to a file",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path to write"},
+                    "content": {"type": "string", "description": "Content to write"}
+                },
+                "required": ["path", "content"]
+            }
+        )
+    ]
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name == "read_file":
+        file_path = WORKSPACE_DIR / arguments["path"]
+        content = file_path.read_text()
+        return [TextContent(type="text", text=content)]
+    elif name == "write_file":
+        file_path = WORKSPACE_DIR / arguments["path"]
+        file_path.write_text(arguments["content"])
+        return [TextContent(type="text", text="File written successfully")]
+
+async def main():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Tool Access Control
+
+Tool access is controlled through the `tool_scopes` configuration. **Only tools with explicit scope mappings are available** - this provides security by default.
 
 ```yaml
 servers:
   - name: "filesystem"
     type: "stdio"
-    command: "uvx"
-    args: ["mcp-server-filesystem", "/workspace"]
-    # Only allow specific tools (if specified, all others are blocked)
-    allowed_tools: ["read_file", "list_directory"]
-    # Or block specific tools (these are excluded even if in allowed_tools)
-    blocked_tools: ["delete_file", "write_file"]
+    command: "python"
+    args: ["/path/to/mcp_server.py"]
     tool_scopes:
+      # ✅ These tools will be available
+      "filesystem:read_file": ["files:read"]
+      "filesystem:write_file": ["files:write"]
+      
+      # ❌ This tool is disabled (commented out)
+      # "filesystem:delete_file": ["files:delete"]
+      
+      # ✅ Include unprefixed names for compatibility
       read_file: ["files:read"]
-      list_directory: ["files:read"]
+      write_file: ["files:write"]
 ```
+
+**Key Points:**
+- **Security by default**: Tools without explicit `tool_scopes` are automatically denied
+- **No separate allow/block lists needed**: Simply configure or comment out tools in `tool_scopes`
+- **Clear security intent**: Each tool's required permissions are explicitly documented
 
 ### HTTP-based MCP Servers
 
@@ -97,8 +173,14 @@ mcp:
       headers:
         Authorization: "Bearer ${GITHUB_TOKEN}"
       timeout: 30                      # Request timeout in seconds (default: 30)
-      # Map tools to scopes
+      
+      # REQUIRED: Map tools to scopes (prefixed with server name)
       tool_scopes:
+        "github:create_issue": ["github:write"]
+        "github:list_issues": ["github:read"] 
+        "github:update_issue": ["github:write"]
+        "github:search_code": ["github:read"]
+        # Include unprefixed for compatibility
         create_issue: ["github:write"]
         list_issues: ["github:read"]
         update_issue: ["github:write"]
@@ -110,63 +192,101 @@ mcp:
 
 ### Tool-to-Scope Mapping
 
-Each MCP tool can be mapped to one or more AgentUp security scopes. This ensures that:
+Each MCP tool **must** be explicitly mapped to one or more AgentUp security scopes. This ensures:
 
-1. **Access control is enforced**: Users must have the required scopes to use MCP tools
-2. **Audit trail is maintained**: All MCP tool usage is logged
-3. **Principle of least privilege**: Tools only get the permissions they need
+1. **Explicit security configuration**: No tools are available without deliberate security review
+2. **Access control enforcement**: Users must have required scopes to use MCP tools  
+3. **Comprehensive audit trail**: All MCP tool usage is logged with user context
+4. **Principle of least privilege**: Tools only get explicitly granted permissions
 
-Example scope mapping:
+### Scope Configuration Requirements
 
 ```yaml
 servers:
   - name: "database"
-    type: "stdio"
+    type: "stdio" 
     command: "mcp-server-postgres"
     args: ["--connection-string", "${DATABASE_URL}"]
     tool_scopes:
-      # Read operations
+      # REQUIRED: Both prefixed and unprefixed tool names
+      "database:query": ["db:read"]
+      "database:insert": ["db:write"]
+      "database:delete": ["db:write", "db:delete"]
+      
+      # Include unprefixed for compatibility
       query: ["db:read"]
-      list_tables: ["db:read"]
-      describe_table: ["db:read"]
-
-      # Write operations
-      insert: ["db:write"]
-      update: ["db:write"]
+      insert: ["db:write"] 
       delete: ["db:write", "db:delete"]
-
-      # Admin operations
-      create_table: ["db:admin"]
-      drop_table: ["db:admin", "db:delete"]
-      backup: ["db:admin", "db:backup"]
+      
+      # Tools without scope configuration are automatically blocked
+      # create_table: ["db:admin"]  # ❌ Disabled by commenting out
 ```
+
+### Tool Name Prefixing
+
+AgentUp automatically prefixes MCP tool names with the server name to avoid conflicts:
+
+- **Server name**: `filesystem`
+- **Tool name**: `read_file`  
+- **Registered as**: `filesystem:read_file` AND `read_file`
+
+Configure both prefixed and unprefixed names in `tool_scopes` for maximum compatibility.
 
 
 ## Using MCP Tools in Your Agent
 
-Once configured, MCP tools are automatically available to your agent. They can be invoked through:
+Once configured, MCP tools are automatically available to your agent and can be invoked through natural language:
 
-### 1. AI Routing
+### Natural Language Interface
 
-The LLM can automatically select and use MCP tools based on user requests:
+Users can request MCP tool operations using natural language:
 
-```yaml
-# User: "Read the config.json file"
-# Agent automatically uses the filesystem MCP server's read_file tool
+```bash
+# File operations
+"List the files in the /tmp directory"
+"Read the contents of config.json" 
+"Create a file called notes.txt with the content 'Hello World'"
+
+# Database operations  
+"Show me all users from the database"
+"Insert a new user with email john@example.com"
+
+# GitHub operations
+"Create an issue titled 'Bug: Login not working'"
+"List all open pull requests"
 ```
 
-### 2. Direct Invocation in Plugins
+### API Integration
 
-```python
-# In your plugin code
-async def handle_file_operation(task, mcp_tools):
-    # MCP tools are injected when available
-    if 'filesystem.read_file' in mcp_tools:
-        content = await mcp_tools['filesystem.read_file'](
-            path="/workspace/config.json"
-        )
-        return f"File content: {content}"
+MCP tools can be called via the AgentUp API:
+
+```bash
+curl -X POST http://localhost:8000/ \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: admin-key-123" \
+  -d '{
+    "jsonrpc": "2.0", 
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "list files in /tmp"}],
+        "message_id": "msg-001",
+        "kind": "message"
+      }
+    },
+    "id": "req-001"
+  }'
 ```
+
+### Testing MCP Integration
+
+Test your MCP configuration by:
+
+1. **Starting your agent**: `uv run agentup agent serve`
+2. **Checking logs**: Look for MCP tool registration messages
+3. **Making test requests**: Use natural language to invoke tools
+4. **Verifying security**: Test with insufficient scopes to ensure access is denied
 
 ## Exposing Your Agent as an MCP Server
 
@@ -185,48 +305,80 @@ mcp:
 
 ### Common Issues
 
-1. **MCP Server Not Found**
+1. **MCP Tool Not Available**
    ```
-   Error: Failed to start MCP server 'filesystem'
+   INFO: 0 tools available for user
+   WARNING: Failed to filter MCP tools by scopes
    ```
-   - Ensure the command is installed: `pip install mcp-server-filesystem`
-   - Check the command path is correct
-   - Verify environment variables are set
+   - **Cause**: Tool missing from `tool_scopes` configuration
+   - **Fix**: Add tool to `tool_scopes` with required permissions
+   - **Example**: `"filesystem:read_file": ["files:read"]`
 
-2. **Permission Denied**
+2. **MCP Server Connection Failed**
    ```
-   Error: User lacks required scope 'files:write' for tool 'write_file'
+   ERROR: Failed to connect to MCP server filesystem
+   ```
+   - Check the command path is correct and executable
+   - Verify environment variables are set properly
+   - Ensure MCP server script has correct permissions (`chmod +x`)
+   - Test server independently: `python /path/to/mcp_server.py`
+
+3. **Tool Requires Explicit Scope Configuration**
+   ```
+   ERROR: MCP tool 'read_file' requires explicit scope configuration
+   ```
+   - **Cause**: Tool discovered but missing from `tool_scopes`
+   - **Fix**: Add both prefixed and unprefixed tool names:
+     ```yaml
+     tool_scopes:
+       "filesystem:read_file": ["files:read"]
+       read_file: ["files:read"]
+     ```
+
+4. **Permission Denied**
+   ```
+   ERROR: Insufficient permissions for MCP tool
    ```
    - Check the user's API key has the required scopes
-   - Verify tool_scopes mapping is correct
+   - Verify `tool_scopes` mapping matches user permissions
    - Review scope hierarchy in security configuration
 
-3. **Connection Timeout**
+5. **No MCP Client Registered**
    ```
-   Error: MCP server 'github' connection timeout
+   ERROR: MCP tool call failed: No MCP client registered
    ```
-   - Increase `client_timeout` value
-   - Check network connectivity
-   - Verify server URL and authentication
+   - **Cause**: MCP client initialization failed
+   - **Fix**: Check MCP server is running and accessible
+   - Enable debug logging to see detailed error messages
 
 ### Debug Mode
 
-Enable debug logging for MCP:
+Enable debug logging for MCP to see detailed initialization and tool registration:
 
 ```yaml
 logging:
+  enabled: true
+  level: "DEBUG"
   modules:
-    agent.mcp_support: "DEBUG"
-    agent.services.mcp: "DEBUG"
+    "agent.mcp_support": "DEBUG"
+    "agent.services.mcp": "DEBUG"
+    "agent.core.dispatcher": "DEBUG"
 ```
+
+**Key debug messages to look for:**
+- `✓ MCP clients initialized: 1`
+- `✓ Registered MCP tool as capability: filesystem_read_file`
+- `✓ Registered MCP client with function registry`
+- `✓ AI tool filtering completed: 3 tools available`
 
 ## Best Practices
 
-1. **Scope Design**: Create a logical scope hierarchy that matches your security model
-2. **Tool Naming**: Use descriptive names that indicate the tool's purpose and required permissions
-3. **Error Handling**: MCP tools should gracefully handle errors and provide meaningful messages
-4. **Documentation**: Document required scopes and tool parameters for each MCP server
-5. **Testing**: Test MCP integrations with reduced permissions to ensure security
+1. **Explicit Security Configuration**: Always configure `tool_scopes` for every tool you want to expose
+2. **Include Both Prefixed and Unprefixed Names**: Configure `"server:tool"` and `tool` for maximum compatibility
+3. **Scope Hierarchy**: Leverage AgentUp's scope inheritance (e.g., `files:admin` → `files:write` → `files:read`)
+4. **Test Security**: Verify tools are blocked when scopes are missing or insufficient
+5. **Debug Logging**: Enable debug logging during setup to verify tool registration
+6. **Environment Variables**: Use `${VAR}` syntax for sensitive configuration like API keys
 
 ## Example: Complete MCP Configuration
 
@@ -236,64 +388,74 @@ mcp:
   enabled: true
   client_enabled: true
   client_timeout: 30
-  client_retry_attempts: 3             # Client retry attempts (default: 3)
+  client_retry_attempts: 3
 
   # Optional: Expose agent as MCP server
   server_enabled: true
-  server_host: "localhost"
-  server_port: 8080
+  server_host: "0.0.0.0"
+  server_port: 8001
 
   # Connected MCP servers
   servers:
-    # Filesystem access
+    # Python-based filesystem server
     - name: "filesystem"
       type: "stdio"
-      command: "uvx"
-      args: ["mcp-server-filesystem", "/workspace"]
+      command: "python"
+      args: ["/path/to/filesystem_mcp_server.py"]
       env:
-        WORKSPACE_ROOT: "/workspace"
-        READONLY: "false"
+        DEBUG: "1"
+      working_dir: "/tmp"
       tool_scopes:
+        # REQUIRED: Both prefixed and unprefixed tool names
+        "filesystem:read_file": ["files:read"]
+        "filesystem:write_file": ["files:write"]
+        "filesystem:list_directory": ["files:read"]
+        # Include unprefixed for compatibility
         read_file: ["files:read"]
         write_file: ["files:write"]
         list_directory: ["files:read"]
-        create_directory: ["files:write"]
-        delete_file: ["files:delete"]
 
-    # GitHub integration
+    # GitHub HTTP MCP server
     - name: "github"
       type: "http"
-      url: "https://api.github.com/mcp"
+      url: "http://localhost:3000/mcp"
       headers:
         Authorization: "Bearer ${GITHUB_TOKEN}"
-        Accept: "application/vnd.github.v3+json"
       timeout: 30
       tool_scopes:
-        # Repository operations
-        list_repos: ["github:read"]
-        create_repo: ["github:write"]
-        delete_repo: ["github:admin"]
-
-        # Issue operations
-        list_issues: ["github:read"]
+        # Prefixed tool names (required)
+        "github:create_issue": ["github:write"]
+        "github:list_issues": ["github:read"]
+        "github:update_issue": ["github:write"]
+        # Unprefixed for compatibility
         create_issue: ["github:write"]
+        list_issues: ["github:read"]
         update_issue: ["github:write"]
-        close_issue: ["github:write"]
+        # Disabled tool (commented out)
+        # "github:delete_repo": ["github:admin"]
 
-        # PR operations
-        list_prs: ["github:read"]
-        create_pr: ["github:write"]
-        merge_pr: ["github:write", "github:merge"]
-
-    # Database access
-    - name: "postgres"
-      type: "stdio"
-      command: "mcp-server-postgres"
-      args: ["--connection-string", "${DATABASE_URL}"]
-      tool_scopes:
-        query: ["db:connect", "db:read"]
-        insert: ["db:connect", "db:write"]
-        update: ["db:connect", "db:write"]
-        delete: ["db:connect", "db:write", "db:delete"]
-        execute_ddl: ["db:connect", "db:admin"]
+# Security configuration for MCP tool access
+security:
+  enabled: true
+  scope_hierarchy:
+    admin: ["*"]
+    files:admin: ["files:write", "files:read"]
+    files:write: ["files:read"]
+    github:admin: ["github:write", "github:read"]
+    github:write: ["github:read"]
+  auth:
+    api_key:
+      header_name: "X-API-Key"
+      keys:
+        - key: "admin-key-123"
+          scopes: ["files:write", "github:read"]
 ```
+
+## Quick Start
+
+1. **Create an MCP server script** (Python example above)
+2. **Configure your `agentup.yml`** with server connection and tool scopes
+3. **Start your agent**: `uv run agentup agent serve`
+4. **Test with natural language**: "List files in /tmp directory"
+
+That's it! Your agent now has MCP tool capabilities with full security integration.

--- a/docs/mcp/mcp-integration.md
+++ b/docs/mcp/mcp-integration.md
@@ -52,7 +52,7 @@ mcp:
       env:
         DEBUG: "1"                   # Optional environment variables
       working_dir: "/tmp"            # Optional: Set working directory for the server process
-      
+
       # REQUIRED: Map MCP tools to AgentUp security scopes
       # Tools are automatically prefixed with server name (e.g., "filesystem:read_file")
       tool_scopes:
@@ -98,7 +98,7 @@ async def list_tools() -> list[Tool]:
             }
         ),
         Tool(
-            name="write_file", 
+            name="write_file",
             description="Write contents to a file",
             inputSchema={
                 "type": "object",
@@ -144,10 +144,10 @@ servers:
       # ✅ These tools will be available
       "filesystem:read_file": ["files:read"]
       "filesystem:write_file": ["files:write"]
-      
+
       # ❌ This tool is disabled (commented out)
       # "filesystem:delete_file": ["files:delete"]
-      
+
       # ✅ Include unprefixed names for compatibility
       read_file: ["files:read"]
       write_file: ["files:write"]
@@ -173,11 +173,11 @@ mcp:
       headers:
         Authorization: "Bearer ${GITHUB_TOKEN}"
       timeout: 30                      # Request timeout in seconds (default: 30)
-      
+
       # REQUIRED: Map tools to scopes (prefixed with server name)
       tool_scopes:
         "github:create_issue": ["github:write"]
-        "github:list_issues": ["github:read"] 
+        "github:list_issues": ["github:read"]
         "github:update_issue": ["github:write"]
         "github:search_code": ["github:read"]
         # Include unprefixed for compatibility
@@ -195,7 +195,7 @@ mcp:
 Each MCP tool **must** be explicitly mapped to one or more AgentUp security scopes. This ensures:
 
 1. **Explicit security configuration**: No tools are available without deliberate security review
-2. **Access control enforcement**: Users must have required scopes to use MCP tools  
+2. **Access control enforcement**: Users must have required scopes to use MCP tools
 3. **Comprehensive audit trail**: All MCP tool usage is logged with user context
 4. **Principle of least privilege**: Tools only get explicitly granted permissions
 
@@ -204,7 +204,7 @@ Each MCP tool **must** be explicitly mapped to one or more AgentUp security scop
 ```yaml
 servers:
   - name: "database"
-    type: "stdio" 
+    type: "stdio"
     command: "mcp-server-postgres"
     args: ["--connection-string", "${DATABASE_URL}"]
     tool_scopes:
@@ -212,12 +212,12 @@ servers:
       "database:query": ["db:read"]
       "database:insert": ["db:write"]
       "database:delete": ["db:write", "db:delete"]
-      
+
       # Include unprefixed for compatibility
       query: ["db:read"]
-      insert: ["db:write"] 
+      insert: ["db:write"]
       delete: ["db:write", "db:delete"]
-      
+
       # Tools without scope configuration are automatically blocked
       # create_table: ["db:admin"]  # ❌ Disabled by commenting out
 ```
@@ -227,7 +227,7 @@ servers:
 AgentUp automatically prefixes MCP tool names with the server name to avoid conflicts:
 
 - **Server name**: `filesystem`
-- **Tool name**: `read_file`  
+- **Tool name**: `read_file`
 - **Registered as**: `filesystem:read_file` AND `read_file`
 
 Configure both prefixed and unprefixed names in `tool_scopes` for maximum compatibility.
@@ -244,10 +244,10 @@ Users can request MCP tool operations using natural language:
 ```bash
 # File operations
 "List the files in the /tmp directory"
-"Read the contents of config.json" 
+"Read the contents of config.json"
 "Create a file called notes.txt with the content 'Hello World'"
 
-# Database operations  
+# Database operations
 "Show me all users from the database"
 "Insert a new user with email john@example.com"
 
@@ -265,7 +265,7 @@ curl -X POST http://localhost:8000/ \
   -H "Content-Type: application/json" \
   -H "X-API-Key: admin-key-123" \
   -d '{
-    "jsonrpc": "2.0", 
+    "jsonrpc": "2.0",
     "method": "message/send",
     "params": {
       "message": {

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -174,8 +174,6 @@ class MCPServerConfig(BaseModel):
 
     # Tool permissions
     tool_scopes: dict[str, list[str]] = Field(default_factory=dict, description="Tool name to required scopes mapping")
-    allowed_tools: list[str] | None = Field(None, description="Allowed tools (None = all)")
-    blocked_tools: list[str] = Field(default_factory=list, description="Blocked tools")
 
     @model_validator(mode="after")
     def validate_server_config(self) -> MCPServerConfig:

--- a/src/agent/core/dispatcher.py
+++ b/src/agent/core/dispatcher.py
@@ -237,7 +237,12 @@ class FunctionRegistry:
         # Extract tool scopes from server configuration
         tool_scopes = {}
         for server_config in servers:
-            server_tool_scopes = server_config.get("tool_scopes", {})
+            # Handle Pydantic model (use attribute access, not .get())
+            if hasattr(server_config, "tool_scopes"):
+                server_tool_scopes = server_config.tool_scopes or {}
+            else:
+                # Fallback for dict-like objects
+                server_tool_scopes = server_config.get("tool_scopes", {}) if hasattr(server_config, "get") else {}
             tool_scopes.update(server_tool_scopes)
 
         # Filter MCP tools based on scopes

--- a/src/agent/core/dispatcher.py
+++ b/src/agent/core/dispatcher.py
@@ -235,15 +235,9 @@ class FunctionRegistry:
         servers = Config.mcp.servers
 
         # Extract tool scopes from server configuration
-        tool_scopes = {}
-        for server_config in servers:
-            # Handle Pydantic model (use attribute access, not .get())
-            if hasattr(server_config, "tool_scopes"):
-                server_tool_scopes = server_config.tool_scopes or {}
-            else:
-                # Fallback for dict-like objects
-                server_tool_scopes = server_config.get("tool_scopes", {}) if hasattr(server_config, "get") else {}
-            tool_scopes.update(server_tool_scopes)
+        from agent.mcp_support.mcp_integration import _extract_tool_scopes_from_servers
+
+        tool_scopes = _extract_tool_scopes_from_servers(servers)
 
         # Filter MCP tools based on scopes
         for tool_name, tool_schema in self._mcp_tools.items():

--- a/src/agent/mcp_support/__init__.py
+++ b/src/agent/mcp_support/__init__.py
@@ -1,11 +1,3 @@
-"""
-AgentUp MCP (Model Context Protocol) Support.
-
-This module provides MCP protocol implementation for the AgentUp framework
-including client/server communication, resource management, and tool integration.
-"""
-
-# Import key MCP models for easy access
 from .model import (
     MCPCapability,
     MCPMessage,


### PR DESCRIPTION
- Problem: Code expected nested config (mcp.client.enabled) but model used flat structure (mcp.client_enabled)
- Solution: Updated initialization code to use the correct Pydantic model structure

- Problem: Code used .get() method on Pydantic models instead of attribute access
- Solution: Added proper Pydantic model handling with fallback for dict objects

- Problem: MCP tools were registered but client wasn't, causing "No MCP client registered" errors
- Solution: Added client registration in both success and failure scenarios

- Removed: Redundant allowed_tools and blocked_tools configuration

Users can just comment out !
