### PR TITLE
Removed the non-existent get_loaded_plugins() method call and implemented a registry-only approach

### DIFF
--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -214,14 +214,12 @@ def create_agent_card(extended: bool = False) -> AgentCard:
 
     registry = get_plugin_registry()
     if registry and registry.plugins:
+        # Create a lookup for plugin configurations by their ID for efficient access
+        plugins_by_id = {p.get("plugin_id"): p for p in plugins if p.get("plugin_id")}
+
         # Get loaded plugins from the registry's plugins attribute
         for plugin_id, _plugin_instance in registry.plugins.items():
-            # Find corresponding config
-            plugin_config = None
-            for p in plugins:
-                if p.get("plugin_id") == plugin_id:
-                    plugin_config = p
-                    break
+            plugin_config = plugins_by_id.get(plugin_id)
 
             if plugin_config:
                 plugin_visibility = plugin_config.get("visibility", "public")

--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -209,62 +209,38 @@ def create_agent_card(extended: bool = False) -> AgentCard:
     # Add MCP tools as skills
     agent_skills.extend(_get_mcp_skills_for_agent_card())
 
-    # Try to get plugin information from the new system
-    try:
-        from agent.plugins.manager import get_plugin_registry
+    # Get plugin information from the plugin registry
+    from agent.plugins.manager import get_plugin_registry
 
-        registry = get_plugin_registry()
-        if registry:
-            # Get loaded plugins from the registry
-            loaded_plugins = registry.get_loaded_plugins()
-            for plugin_id, _plugin_info in loaded_plugins.items():
-                # Find corresponding config
-                plugin_config = None
-                for p in plugins:
-                    if p.get("plugin_id") == plugin_id:
-                        plugin_config = p
-                        break
+    registry = get_plugin_registry()
+    if registry and registry.plugins:
+        # Get loaded plugins from the registry's plugins attribute
+        for plugin_id, _plugin_instance in registry.plugins.items():
+            # Find corresponding config
+            plugin_config = None
+            for p in plugins:
+                if p.get("plugin_id") == plugin_id:
+                    plugin_config = p
+                    break
 
-                if plugin_config:
-                    plugin_visibility = plugin_config.get("visibility", "public")
+            if plugin_config:
+                plugin_visibility = plugin_config.get("visibility", "public")
 
-                    # Track if any extended plugins exist
-                    if plugin_visibility == "extended":
-                        has_extended_plugins = True
+                # Track if any extended plugins exist
+                if plugin_visibility == "extended":
+                    has_extended_plugins = True
 
-                    # Include plugin in card based on visibility and card type
-                    if plugin_visibility == "public" or (extended and plugin_visibility == "extended"):
-                        agent_skill = AgentSkill(
-                            id=plugin_id,
-                            name=plugin_config.get("name") or plugin_id,
-                            description=plugin_config.get("description") or f"Plugin {plugin_id}",
-                            inputModes=[plugin_config.get("input_mode", "text")],
-                            outputModes=[plugin_config.get("output_mode", "text")],
-                            tags=plugin_config.get("tags", ["general"]),
-                        )
-                        agent_skills.append(agent_skill)
-    except (ImportError, Exception) as e:
-        logger.debug(f"Could not get plugins from new registry: {e}")
-
-        # Fallback to old config-based approach
-        for plugin in plugins:
-            plugin_visibility = plugin.get("visibility", "public")
-
-            # Track if any extended plugins exist
-            if plugin_visibility == "extended":
-                has_extended_plugins = True
-
-            # Include plugin in card based on visibility and card type
-            if plugin_visibility == "public" or (extended and plugin_visibility == "extended"):
-                agent_skill = AgentSkill(
-                    id=plugin.get("plugin_id"),
-                    name=plugin.get("name") or plugin.get("plugin_id", "Unknown Plugin"),
-                    description=plugin.get("description") or f"Plugin {plugin.get('plugin_id', 'unknown')}",
-                    inputModes=[plugin.get("input_mode", "text")],
-                    outputModes=[plugin.get("output_mode", "text")],
-                    tags=plugin.get("tags", ["general"]),
-                )
-                agent_skills.append(agent_skill)
+                # Include plugin in card based on visibility and card type
+                if plugin_visibility == "public" or (extended and plugin_visibility == "extended"):
+                    agent_skill = AgentSkill(
+                        id=plugin_id,
+                        name=plugin_config.get("name") or plugin_id,
+                        description=plugin_config.get("description") or f"Plugin {plugin_id}",
+                        inputModes=[plugin_config.get("input_mode", "text")],
+                        outputModes=[plugin_config.get("output_mode", "text")],
+                        tags=plugin_config.get("tags", ["general"]),
+                    )
+                    agent_skills.append(agent_skill)
 
     # Create capabilities object with extensions
     extensions = []

--- a/tests/test_core/test_api.py
+++ b/tests/test_core/test_api.py
@@ -75,9 +75,8 @@ class TestAgentCard:
 
         card = create_agent_card()
 
-        assert len(card.skills) == 1
-        assert card.skills[0].id == "chat"
-        assert card.skills[0].name == "Chat"
+        # With registry-only approach, configured plugins don't appear unless loaded in registry
+        assert len(card.skills) == 0
 
     @patch("agent.api.routes.ConfigurationManager")
     def test_create_agent_card_with_security_enabled(self, mock_config_manager):


### PR DESCRIPTION
Removed the non-existent get_loaded_plugins() method call and implemented a registry-only approach for plugin skills in
  agent cards.

  What works now:
  - The code accesses registry.plugins directly (the correct way)
  - Only plugins that are actually loaded in the plugin registry appear as skills in the agent card
  - No backwards compatibility fallback to configuration-only plugins
  - Plugins must be installed as Python packages to appear in the agent card

  The error 'PluginRegistry' object has no attribute 'get_loaded_plugins' is now completely resolved.