### PR TITLE
There are instances of dead code around plugin based sys prompts, but plugin based sys prompts was discussed and agreed to be a poor idea, so its being dropped.

### DIFF
--- a/docs/agentup-development/index.md
+++ b/docs/agentup-development/index.md
@@ -123,7 +123,7 @@ agentup agent create weather-test --template standard
 # Configure agent to use your plugin
 echo "
 skills:
-  - skill_id: weather_plugin
+  - plugin_id: weather_plugin
     routing_mode: ai
 " >> weather-test/agent_config.yaml
 
@@ -546,7 +546,7 @@ agentup agent create test-minimal --template minimal
 cd test-minimal
 
 # Add your plugin
-echo "skills: [{skill_id: your_plugin}]" >> agent_config.yaml
+echo "skills: [{plugin_id: your_plugin}]" >> agent_config.yaml
 
 # Test specific scenarios
 curl -X POST http://localhost:8000/ \
@@ -580,7 +580,7 @@ pip install your-plugin
 ## Configuration
 ```yaml
 skills:
-  - skill_id: your_plugin
+  - plugin_id: your_plugin
     config:
       api_key: ${YOUR_API_KEY}
 ```

--- a/docs/middleware/logging.md
+++ b/docs/middleware/logging.md
@@ -125,7 +125,7 @@ class MyPlugin:
     def execute_skill(self, context):
         logger.info("Plugin processing request",
                    plugin="my_plugin",
-                   skill=context.skill_id,
+                   skill=context.plugin_id,
                    correlation_id=context.correlation_id)
 
         # Your plugin logic here

--- a/docs/plugin-development/plugins-as-tools-explanation.md
+++ b/docs/plugin-development/plugins-as-tools-explanation.md
@@ -155,8 +155,8 @@ mcp:
     expose_handlers: true
 
 skills:
-  - skill_id: analyze_image  # Built-in skill
-  - skill_id: ai_assistant   # AI-powered skill that can call tools
+  - plugin_id: analyze_image  # Built-in skill
+  - plugin_id: ai_assistant   # AI-powered skill that can call tools
 ```
 
 ### 2. Available Tools to LLM
@@ -195,13 +195,13 @@ await mcp_client.call_tool("write_file", {"path": "/tmp/analysis.txt", "content"
 
 ```yaml
 skills:
-  - skill_id: weather_lookup
+  - plugin_id: weather_lookup
     name: Weather Lookup
     description: Get current weather for a location
     tags: [weather, external_api]
     # This skill can be called by LLMs when AI routing is enabled
     
-  - skill_id: file_processor  
+  - plugin_id: file_processor  
     name: File Processor
     description: Process uploaded files
     tags: [file, processing, multimodal]
@@ -217,10 +217,10 @@ routing:
 
 # OR per-skill
 skills:
-  - skill_id: data_analysis
+  - plugin_id: data_analysis
     routing_mode: ai  # Available as LLM tool
     
-  - skill_id: simple_greeting
+  - plugin_id: simple_greeting
     routing_mode: direct  # Direct keyword matching only
     keywords: [hello, hi]
 ```

--- a/scripts/test_rate_limit.sh
+++ b/scripts/test_rate_limit.sh
@@ -274,7 +274,7 @@ echo "- Tested rate limit recovery functionality"
 echo "- Validated JSON responses and error handling"
 echo
 echo -e "${BLUE}Rate Limiting Configuration:${NC}"
-echo "- Rate limiting is applied per skill_id and user combination"
+echo "- Rate limiting is applied per plugin_id and user combination"
 echo "- Different handlers may have different rate limits configured"
 echo "- Rate limited requests return proper JSON-RPC error responses"
 echo "- Rate limits reset over time using token bucket algorithm"

--- a/scripts/test_retry.sh
+++ b/scripts/test_retry.sh
@@ -55,13 +55,13 @@ check_dependencies() {
 # Enhanced function to test retry behavior with timing analysis
 test_retry_scenario() {
     local test_name="$1"
-    local skill_id="$2"
+    local plugin_id="$2"
     local content="$3"
     local expected_behavior="$4"
     local timeout_override="${5:-$TIMEOUT}"
 
     echo -e "${YELLOW}Test: $test_name${NC}"
-    echo "Skill: $skill_id"
+    echo "Skill: $plugin_id"
     echo "Content: $content"
     echo "Expected: $expected_behavior"
     echo
@@ -75,7 +75,7 @@ test_retry_scenario() {
             "jsonrpc": "2.0",
             "method": "send_message",
             "params": {
-                "skill_id": "'"$skill_id"'",
+                "plugin_id": "'"$plugin_id"'",
                 "messages": [{"role": "user", "content": "'"$content"'"}]
             },
             "id": "retry-test-'"$(date +%s)"'"
@@ -313,7 +313,7 @@ response=$(curl -s --max-time 5 -X POST "$SERVER_URL/" \
         "jsonrpc": "2.0", 
         "method": "send_message",
         "params": {
-            "skill_id": "retry_test",
+            "plugin_id": "retry_test",
             "messages": [{"role": "user", "content": "test handler exists"}]
         },
         "id": "handler-check"

--- a/src/agent/cli/commands/deploy.py
+++ b/src/agent/cli/commands/deploy.py
@@ -312,7 +312,7 @@ data:
       description: A2A Agent deployed on Kubernetes
       version: 0.5.1
     skills:
-      - skill_id: hello_world
+      - plugin_id: hello_world
         name: Hello World
         description: A simple greeting
         input_mode: text
@@ -452,7 +452,7 @@ agentConfig: |
     description: A2A Agent deployed with Helm
     version: 0.5.1
   skills:
-    - skill_id: hello_world
+    - plugin_id: hello_world
       name: Hello World
       description: A simple greeting
       input_mode: text

--- a/src/agent/cli/commands/validate.py
+++ b/src/agent/cli/commands/validate.py
@@ -60,9 +60,6 @@ def validate(config: str, check_env: bool, check_handlers: bool, strict: bool):
     if "ai" in config_data:
         validate_system_prompt_section(config_data["ai"], errors, warnings)
 
-    # Validate plugin system prompts in plugins
-    validate_plugin_system_prompts(config_data.get("plugins", []), errors, warnings)
-
     # Check environment variables
     if check_env:
         check_environment_variables(config_data, errors, warnings)
@@ -556,42 +553,6 @@ def validate_system_prompt_section(ai_config: dict[str, Any], errors: list[str],
         warnings.append("System prompt may lack clear role definition")
 
     click.echo(f"{click.style('✓', fg='green')} System prompt validated")
-
-
-def validate_plugin_system_prompts(plugins: list[dict[str, Any]], errors: list[str], warnings: list[str]):
-    plugin_prompt_count = 0
-
-    for i, plugin in enumerate(plugins):
-        if not isinstance(plugin, dict):
-            continue
-
-        plugin_id = plugin.get("plugin_id", f"plugin_{i}")
-
-        # Check if plugin has plugin-specific system prompt
-        if "system_prompt" in plugin:
-            plugin_prompt_count += 1
-            system_prompt = plugin["system_prompt"]
-
-            if not isinstance(system_prompt, str):
-                errors.append(f"Plugin '{plugin_id}' system_prompt must be a string")
-                continue
-
-            # Validate length
-            if len(system_prompt) < 10:
-                warnings.append(f"Plugin '{plugin_id}' system prompt is very short")
-            elif len(system_prompt) > 4000:
-                warnings.append(f"Plugin '{plugin_id}' system prompt is very long - may impact performance")
-
-            # Check for plugin-specific guidance
-            prompt_lower = system_prompt.lower()
-            plugin_name_lower = plugin.get("name", plugin_id).lower()
-            if plugin_name_lower not in prompt_lower and plugin_id.lower() not in prompt_lower:
-                warnings.append(f"Plugin '{plugin_id}' system prompt may lack plugin-specific guidance")
-
-    if plugin_prompt_count > 0:
-        click.echo(f"{click.style('✓', fg='green')} Plugin system prompts validated ({plugin_prompt_count} found)")
-    else:
-        click.echo(f"{click.style('✓', fg='green')} No plugin system prompts found")
 
 
 def validate_middleware_section(

--- a/src/agent/plugins/adapter.py
+++ b/src/agent/plugins/adapter.py
@@ -266,7 +266,6 @@ class PluginAdapter:
             "output_mode": capability.output_mode,
             "tags": capability.tags,
             "priority": capability.priority,
-            "system_prompt": capability.system_prompt,
         }
 
     def get_ai_functions(self, capability_id: str):

--- a/src/agent/state/conversation.py
+++ b/src/agent/state/conversation.py
@@ -11,33 +11,16 @@ class ConversationManager:
         self.conversation_history: dict[str, list[dict[str, Any]]] = {}
 
     async def prepare_llm_conversation(
-        self, user_input: str | dict[str, Any], conversation: list[dict[str, Any]], skill_id: str | None = None
+        self, user_input: str | dict[str, Any], conversation: list[dict[str, Any]]
     ) -> list[dict[str, str]]:
         # Get system prompt from config
         from agent.config import Config
 
         ai_config = Config.ai
-
-        # Check if we have a skill-specific system prompt
-        skill_system_prompt = None
-        if skill_id:
-            try:
-                from agent.plugins.integration import get_skill_info
-
-                skill_info = get_skill_info(skill_id)
-                skill_system_prompt = skill_info.get("system_prompt")
-            except Exception as e:
-                logger.warning(f"Could not get skill info for {skill_id}: {e}")
-
-        # Use skill-specific system prompt if available, otherwise use global config
-        if skill_system_prompt:
-            system_prompt = skill_system_prompt
-        else:
-            # Use configured system prompt or fallback to default
-            # TODO: Need to move all these prompts to config
-            system_prompt = ai_config.get(
-                "system_prompt",
-                """You are an AI agent with access to specific functions/skills.
+        # Use configured system prompt or fallback to default
+        system_prompt = ai_config.get(
+            "system_prompt",
+            """You are an AI agent with access to specific functions/skills.
 
 Your role:
 - Understand user requests naturally
@@ -52,7 +35,7 @@ When users ask for something:
 4. If no function is needed, respond conversationally
 
 Always be helpful, accurate, and maintain a friendly tone.""",
-            )
+        )
 
         messages = [{"role": "system", "content": system_prompt}]
 

--- a/src/agent/templates/README.md.j2
+++ b/src/agent/templates/README.md.j2
@@ -79,7 +79,7 @@ pip install git+https://github.com/user/agentup-plugin-name
 **Modify Agent Behavior** (`agentup.yml`):
 ```yaml
 skills:
-  - skill_id: my_plugin_skill  # From installed plugin
+  - plugin_id: my_plugin_skill  # From installed plugin
     name: My Skill
     description: Custom skill via plugin
     tags: [custom, business]

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -108,7 +108,7 @@ class TestTestHelpers:
         assert "openai" in config["services"]
         assert config["services"]["openai"]["settings"]["model"] == "gpt-4"
         assert len(config["skills"]) == 1
-        assert config["skills"][0]["skill_id"] == "test_skill"
+        assert config["skills"][0]["plugin_id"] == "test_skill"
 
     def test_build_predefined_configs(self):
         minimal = build_minimal_config()
@@ -117,7 +117,7 @@ class TestTestHelpers:
         # Test minimal
         assert minimal["agent"]["name"] == "minimal-test"
         assert len(minimal["skills"]) == 1
-        assert minimal["skills"][0]["skill_id"] == "echo"
+        assert minimal["skills"][0]["plugin_id"] == "echo"
 
         # Test standard
         assert standard["agent"]["name"] == "standard-test"

--- a/tests/test_state/test_auto_application.py
+++ b/tests/test_state/test_auto_application.py
@@ -80,7 +80,7 @@ class TestStateConfigResolution:
 
     def test_resolve_state_config_global(self):
         global_config = {"enabled": True, "backend": "memory"}
-        skill_config = {"skill_id": "test_skill", "name": "Test Skill"}
+        skill_config = {"plugin_id": "test_skill", "name": "Test Skill"}
 
         with patch("src.agent.handlers.handlers._load_state_config", return_value=global_config):
             with patch("src.agent.handlers.handlers._get_plugin_config", return_value=skill_config):
@@ -91,7 +91,7 @@ class TestStateConfigResolution:
     def test_resolve_state_config_skill_override(self):
         global_config = {"enabled": True, "backend": "memory"}
         skill_config = {
-            "skill_id": "test_skill",
+            "plugin_id": "test_skill",
             "name": "Test Skill",
             "state_override": {"enabled": True, "backend": "file", "config": {"storage_dir": "/tmp"}},
         }
@@ -262,7 +262,7 @@ class TestGlobalStateApplication:
         with patch("src.agent.handlers.handlers._load_state_config", return_value=state_config):
             with patch("src.agent.handlers.handlers._apply_state_to_handler") as mock_apply_state:
                 # Mock apply_state to return a "wrapped" version
-                def mock_apply(handler, skill_id):
+                def mock_apply(handler, plugin_id):
                     wrapped = AsyncMock()
                     wrapped._agentup_state_applied = True
                     return wrapped
@@ -343,7 +343,7 @@ class TestGlobalStateApplication:
         with patch("src.agent.handlers.handlers._load_state_config", return_value=state_config):
             with patch("src.agent.handlers.handlers._apply_state_to_handler") as mock_apply_state:
                 # Mock apply_state to return a "wrapped" version
-                def mock_apply(handler, skill_id):
+                def mock_apply(handler, plugin_id):
                     wrapped = AsyncMock()
                     wrapped._agentup_state_applied = True
                     return wrapped

--- a/tests/utils/plugin_testing.py
+++ b/tests/utils/plugin_testing.py
@@ -141,11 +141,11 @@ class PluginTestRunner:
         return results
 
 
-def create_test_plugin(skill_id: str, name: str) -> type:
+def create_test_plugin(plugin_id: str, name: str) -> type:
     class TestPlugin:
         def register_capability(self) -> CapabilityDefinition:
             return CapabilityDefinition(
-                id=skill_id,
+                id=plugin_id,
                 name=name,
                 version="1.0.0",
                 description=f"Test plugin: {name}",
@@ -162,7 +162,7 @@ def create_test_plugin(skill_id: str, name: str) -> type:
 
         def execute_capability(self, context: CapabilityContext) -> CapabilityResult:
             return CapabilityResult(
-                content=f"Executed {skill_id}",
+                content=f"Executed {plugin_id}",
                 success=True,
             )
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -36,7 +36,7 @@ def create_test_agent_config(
         "routing": {"default_mode": "ai", "fallback_capability": "ai_assistant"},
         "skills": [
             {
-                "skill_id": "ai_assistant",
+                "plugin_id": "ai_assistant",
                 "name": "AI Assistant",
                 "description": "General purpose AI assistant",
                 "input_mode": "text",
@@ -246,14 +246,14 @@ class AgentConfigBuilder:
     def with_anthropic_service(self, name: str = "anthropic", model: str = "claude-3-haiku-20240307"):
         return self.with_service(name, "llm", provider="anthropic", api_key="${ANTHROPIC_API_KEY}", model=model)
 
-    def with_skill(self, skill_id: str, name: str = None, **config):
+    def with_skill(self, plugin_id: str, name: str = None, **config):
         if "skills" not in self.config:
             self.config["skills"] = []
 
         skill = {
-            "skill_id": skill_id,
-            "name": name or skill_id.replace("_", " ").title(),
-            "description": f"Test skill {skill_id}",
+            "plugin_id": plugin_id,
+            "name": name or plugin_id.replace("_", " ").title(),
+            "description": f"Test skill {plugin_id}",
             "input_mode": "text",
             "output_mode": "text",
             **config,


### PR DESCRIPTION
---
name: 🛠️ Pull Request
about: Submit a code contribution to AgentUp
title: "[PR]: Remove instances of dead code" 
labels: ''
assignees: ''

---

## 📝 Description

Remove instances of dead code around plugin system prompts

Why Single System Prompt is Better

  1. Identity Coherence

  An agent should maintain a consistent identity throughout a conversation. Imagine:
  User: "Help me debug this code"
  Agent: [Professional, technical tone from code_review skill prompt]
  User: "Thanks! Can you also check the weather?"
  Agent: [Suddenly casual, different personality from weather skill prompt]
  This personality switching would be jarring and confusing.

  2. The Skills-as-Tools Mental Model

  Skills/plugins should be tools the agent uses, not personalities it adopts. Think of it like:
  - A human assistant doesn't change their personality when using different tools
  - They might adjust their communication style slightly, but their core identity remains
  - The tools provide capabilities, not identity changes

  3. Security & Predictability

  - Single prompt = single attack surface to defend
  - Predictable behavior = better user trust
  - Easier to audit and reason about

  4. State Management Complexity

  With skill-specific prompts, you'd have impossible questions:
  - What if multiple skills are used in one response?
  - Which prompt "wins"?
  - How do you merge conflicting instructions?
  - What prompt applies to the final synthesis of results?

  This way:
  - The agent maintains its identity
  - Skills provide guidance through their descriptions
  - The LLM naturally adapts its tool usage without personality changes
