### PR TITLE
Report AgentCard, remove uneeded imports, use A2A Types

### DIFF
--- a/src/agent/a2a/__init__.py
+++ b/src/agent/a2a/__init__.py
@@ -1,0 +1,6 @@
+from .agentcard import clear_agent_card_cache, create_agent_card
+
+__all__ = [
+    "create_agent_card",
+    "clear_agent_card_cache",
+]

--- a/src/agent/a2a/agentcard.py
+++ b/src/agent/a2a/agentcard.py
@@ -1,0 +1,332 @@
+import importlib.metadata
+
+import structlog
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentCardSignature,
+    AgentExtension,
+    AgentProvider,
+    AgentSkill,
+    APIKeySecurityScheme,
+    HTTPAuthSecurityScheme,
+)
+
+from agent.services.config import ConfigurationManager
+
+logger = structlog.get_logger(__name__)
+
+# Agent card caching - Force cache invalidation for debugging
+_cached_agent_card: AgentCard | None = None
+_cached_extended_agent_card: AgentCard | None = None
+_cached_config_hash: str | None = None
+
+
+def create_agent_card(extended: bool = False) -> AgentCard:
+    """Create agent card with current configuration.
+
+    Args:
+        extended: If True, include plugins with visibility="extended" in addition to public plugins
+    """
+    import hashlib
+
+    global _cached_agent_card, _cached_extended_agent_card, _cached_config_hash
+
+    # Get configuration from the cached ConfigurationManager
+    config_manager = ConfigurationManager()
+    config = config_manager.config
+
+    # Create a hash of the configuration to detect changes
+    config_str = str(sorted(config.items()))
+    # Bandit issue: B324 - Using hashlib.md5() is acceptable here for caching purposes
+    current_config_hash = hashlib.md5(config_str.encode()).hexdigest()  # nosec
+
+    # Check if we can use cached version
+    if _cached_config_hash == current_config_hash:
+        if extended and _cached_extended_agent_card is not None:
+            logger.debug("Using cached extended AgentCard")
+            return _cached_extended_agent_card
+        elif not extended and _cached_agent_card is not None:
+            logger.debug("Using cached AgentCard")
+            return _cached_agent_card
+
+    # Cache miss - regenerate agent card
+    agent_info = config.get("agent", {})
+    plugins = config.get("plugins", [])
+
+    # Only log plugins when actually regenerating (cache miss)
+    logger.debug(f"Regenerating agent card - loaded {len(plugins)} plugins from config")
+
+    # Convert plugins to A2A Skill format based on visibility
+    agent_skills = []
+    has_extended_plugins = False
+
+    # Add MCP tools as skills
+    agent_skills.extend(_get_mcp_skills_for_agent_card())
+
+    # Get plugin information from the plugin registry
+    from agent.plugins.manager import get_plugin_registry
+
+    registry = get_plugin_registry()
+    if registry and registry.plugins:
+        # Create a lookup for plugin configurations by their ID for efficient access
+        plugins_by_id = {p.get("plugin_id"): p for p in plugins if p.get("plugin_id")}
+
+        # Get loaded plugins from the registry's plugins attribute
+        for plugin_id, _plugin_instance in registry.plugins.items():
+            plugin_config = plugins_by_id.get(plugin_id)
+
+            if plugin_config:
+                plugin_visibility = plugin_config.get("visibility", "public")
+
+                # Track if any extended plugins exist
+                if plugin_visibility == "extended":
+                    has_extended_plugins = True
+
+                # Include plugin in card based on visibility and card type
+                if plugin_visibility == "public" or (extended and plugin_visibility == "extended"):
+                    agent_skill = AgentSkill(
+                        id=plugin_id,
+                        name=plugin_config.get("name") or plugin_id,
+                        description=plugin_config.get("description") or f"Plugin {plugin_id}",
+                        inputModes=[plugin_config.get("input_mode", "text")],
+                        outputModes=[plugin_config.get("output_mode", "text")],
+                        tags=plugin_config.get("tags", ["general"]),
+                    )
+                    agent_skills.append(agent_skill)
+
+    # Create capabilities object with extensions
+    extensions = []
+
+    # Add MCP extension if enabled
+    mcp_config = config.get("mcp", {})
+    if mcp_config.get("enabled") and mcp_config.get("server", {}).get("enabled"):
+        mcp_extension = AgentExtension(
+            uri="https://modelcontextprotocol.io/mcp/1.0",
+            description="Agent supports MCP for tool sharing and collaboration",
+            params={
+                "endpoint": "/mcp",
+                "transport": "http",
+                "authentication": "api_key",
+            },
+            required=False,
+        )
+        extensions.append(mcp_extension)
+
+    pushNotifications = config.get("push_notifications", {})
+    state_management = config.get("state_management", {})
+
+    capabilities = AgentCapabilities(
+        streaming=True,  # this is always true, as we support non-streaming and streaming methods
+        push_notifications=pushNotifications.get("enabled", False),
+        state_transition_history=state_management.get("enabled", False),
+        extensions=extensions if extensions else None,
+    )
+
+    # Create security schemes based on configuration
+    security_config = config.get("security", {})
+    security_schemes = {}
+    security_requirements = []
+
+    # Get protocol version from a2a-sdk package
+    protocol_version = _get_package_version("a2a-sdk")
+    if security_config.get("enabled", False):
+        auth_type = security_config.get("type", "api_key")
+
+        if auth_type == "api_key":
+            # API Key authentication
+            api_key_scheme = APIKeySecurityScheme.model_validate(
+                {
+                    "name": "X-API-Key",
+                    "description": "API key for authentication",
+                    "in": "header",  # <- use the JSON alias
+                    "type": "apiKey",
+                }
+            )
+            security_schemes["X-API-Key"] = api_key_scheme.model_dump(by_alias=True)
+            security_requirements.append({"X-API-Key": []})
+
+        elif auth_type == "bearer":
+            # Bearer Token authentication
+            bearer_scheme = HTTPAuthSecurityScheme(
+                scheme="bearer", description="Bearer token for authentication", type="http"
+            )
+            security_schemes["BearerAuth"] = bearer_scheme.model_dump(by_alias=True)
+            security_requirements.append({"BearerAuth": []})
+
+        elif auth_type == "oauth2":
+            # OAuth2 Bearer Token authentication
+            oauth2_config = security_config.get("oauth2", {})
+            required_scopes = oauth2_config.get("required_scopes", [])
+
+            oauth2_scheme = HTTPAuthSecurityScheme(
+                scheme="bearer",
+                description="OAuth2 Bearer token for authentication",
+                type="http",
+                bearerFormat="JWT",  # Indicate JWT format for OAuth2
+            )
+            security_schemes["OAuth2"] = oauth2_scheme.model_dump(by_alias=True)
+            security_requirements.append({"OAuth2": required_scopes})
+
+    # Create the official AgentCard
+    # Get version from package metadata, fallback to default
+    package_version = _get_package_version("agentup")
+
+    # Create signatures object only if we have actual signature data
+    signatures = None
+    signature_header = agent_info.get("signature_header")
+    signature_protected = agent_info.get("signature_protected")
+    signature_value = agent_info.get("signature")
+
+    if signature_header and signature_protected and signature_value:
+        signatures = AgentCardSignature(
+            header=signature_header,
+            protected=signature_protected,
+            signature=signature_value,
+        )
+
+    agent_card = AgentCard(
+        protocol_version=protocol_version,
+        name=agent_info.get("name", config.get("project_name", "Agent")),
+        description=agent_info.get("description", config.get("description", "AI Agent")),
+        url=agent_info.get("url", config.get("url", "http://localhost:8000")),
+        preferred_transport="JSONRPC",
+        provider=AgentProvider(
+            organization=agent_info.get("provider_organization", "AgentUp"),
+            url=agent_info.get("provider_url", "http://localhost:8000"),
+        ),
+        icon_url=agent_info.get(
+            "icon_url",
+            config.get(
+                "icon_url", "https://raw.githubusercontent.com/RedDotRocket/AgentUp/refs/heads/main/assets/icon.png"
+            ),
+        ),
+        version=agent_info.get("version", package_version),
+        documentationUrl=agent_info.get(
+            "documentation_url",
+            config.get("documentation_url", "https://docs.agentup.dev"),
+        ),
+        capabilities=capabilities,
+        security=security_requirements if security_requirements else None,
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        skills=agent_skills,
+        securitySchemes=security_schemes if security_schemes else None,
+        signatures=signatures,
+        supportsAuthenticatedExtendedCard=has_extended_plugins,
+    )
+
+    # Update cache
+    _cached_config_hash = current_config_hash
+    if extended:
+        _cached_extended_agent_card = agent_card
+    else:
+        _cached_agent_card = agent_card
+
+    return agent_card
+
+
+def _get_mcp_skills_for_agent_card() -> list[AgentSkill]:
+    """Convert registered MCP capabilities to AgentSkill objects.
+
+    Only includes MCP tools from servers with expose_as_skills: true.
+
+    Returns:
+        List of AgentSkill objects representing MCP tools
+    """
+    from agent.capabilities.manager import get_mcp_capabilities
+    from agent.services.config import ConfigurationManager
+
+    mcp_skills = []
+    try:
+        # Get MCP server configuration to check expose_as_skills flags
+        config_manager = ConfigurationManager()
+        config = config_manager.config
+
+        mcp_config = config.get("mcp", {})
+        if not mcp_config.get("enabled"):
+            return mcp_skills
+        servers = mcp_config.get("servers", [])
+
+        # Create a mapping of server names to expose_as_skills setting
+        server_expose_flags = {}
+        for server in servers:
+            # TODO: Pydantic validation for server config
+            server_name = server.get("name")
+            expose_flag = server.get("expose_as_skills", False)
+
+            server_expose_flags[server_name] = expose_flag
+
+        mcp_capabilities = get_mcp_capabilities()
+
+        # If no capabilities are available, return empty list
+        if not mcp_capabilities:
+            return mcp_skills
+
+        for capability_id, capability_info in mcp_capabilities.items():
+            # Only include capabilities from servers with expose_as_skills: true
+            server_name = capability_info.server_name
+
+            # Add server name to capability ID for uniqueness
+            name = f"{server_name}:{capability_id}" if server_name else capability_id
+
+            if server_expose_flags.get(server_name, False):
+                logger.debug(
+                    f"Including capability '{capability_id}' in AgentCard (server '{server_name}' has expose_as_skills=true)"
+                )
+
+                # Convert MCPCapabilityInfo to AgentSkill
+                skill = AgentSkill(
+                    id=capability_id,
+                    name=name,
+                    description=capability_info.description,
+                    inputModes=["text"],
+                    outputModes=["text"],
+                    tags=["mcp", capability_info.server_name] if capability_info.server_name else ["mcp"],
+                )
+                mcp_skills.append(skill)
+            else:
+                logger.debug(
+                    f"Skipping capability '{capability_id}' (server '{server_name}' has expose_as_skills={server_expose_flags.get(server_name, False)})"
+                )
+
+        if mcp_skills:
+            logger.debug(
+                f"Added {len(mcp_skills)} MCP tools as AgentCard skills from servers with expose_as_skills=true"
+            )
+
+    except Exception as e:
+        logger.error(f"Failed to get MCP capabilities for AgentCard: {e}")
+        import traceback
+
+        logger.error(f"Traceback: {traceback.format_exc()}")
+
+    return mcp_skills
+
+
+def _get_package_version(package_name: str) -> str:
+    """Get the version of a package from metadata.
+
+    Args:
+        package_name: Name of the package to get version for
+
+    Returns:
+        Package version string or "0.0.0" if not found
+    """
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        logger.warning(f"Package '{package_name}' not found in metadata")
+        return "0.0.0"
+    except Exception as e:
+        logger.warning(f"Failed to get version for package '{package_name}': {e}")
+        return "0.0.0"
+
+
+def clear_agent_card_cache() -> None:
+    """Clear the agent card cache to force regeneration."""
+    global _cached_agent_card, _cached_extended_agent_card, _cached_config_hash
+    _cached_agent_card = None
+    _cached_extended_agent_card = None
+    _cached_config_hash = None
+    logger.debug("Agent card cache cleared")

--- a/src/agent/api/__init__.py
+++ b/src/agent/api/__init__.py
@@ -6,7 +6,6 @@ from .app import app, create_app, main
 from .routes import (
     create_agent_card,
     get_request_handler,
-    jsonrpc_error_handler,
     router,
     set_request_handler_instance,
     sse_generator,
@@ -18,7 +17,6 @@ __all__ = [
     "main",
     "create_agent_card",
     "get_request_handler",
-    "jsonrpc_error_handler",
     "router",
     "set_request_handler_instance",
     "sse_generator",

--- a/src/agent/api/app.py
+++ b/src/agent/api/app.py
@@ -8,13 +8,13 @@ from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.tasks import InMemoryTaskStore
 from fastapi import FastAPI
 
-from agent.config.a2a import JSONRPCError
+from agent.a2a.agentcard import create_agent_card
 from agent.config.constants import DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT
 from agent.core.executor import AgentUpExecutor
 from agent.push.notifier import EnhancedPushNotifier
 from agent.services import AgentBootstrapper, ConfigurationManager
 
-from .routes import create_agent_card, jsonrpc_error_handler, router, set_request_handler_instance
+from .routes import router, set_request_handler_instance
 
 # Configure logging
 structlog.contextvars.clear_contextvars()
@@ -34,9 +34,9 @@ async def lifespan(app: FastAPI):
 
         # Now that services (including MCP) are initialized, create the real agent card with MCP skills
         # Clear cache to force regeneration since services may have changed capabilities
-        from agent.api.routes import _clear_agent_card_cache
+        from agent.a2a.agentcard import clear_agent_card_cache
 
-        _clear_agent_card_cache()
+        clear_agent_card_cache()
         app.state.agent_card = create_agent_card()
 
         # Setup request handler with services
@@ -100,9 +100,8 @@ def create_app() -> FastAPI:
     # Configure middleware
     _configure_middleware(app)
 
-    # Add routes and exception handlers
+    # Add routes
     app.include_router(router)
-    app.add_exception_handler(JSONRPCError, jsonrpc_error_handler)
 
     return app
 

--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any
@@ -7,10 +6,12 @@ import structlog
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.jsonrpc_handler import JSONRPCHandler
 from a2a.types import (
+    AgentCard,
     CancelTaskRequest,
     GetTaskPushNotificationConfigRequest,
     GetTaskRequest,
     InternalError,
+    JSONRPCError,
     JSONRPCErrorResponse,
     SendMessageRequest,
     SendStreamingMessageRequest,
@@ -20,17 +21,7 @@ from a2a.types import (
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from agent.config.a2a import (
-    AgentCapabilities,
-    AgentCard,
-    AgentCardSignature,
-    AgentExtension,
-    AgentProvider,
-    AgentSkill,
-    APIKeySecurityScheme,
-    HTTPAuthSecurityScheme,
-    JSONRPCError,
-)
+from agent.a2a.agentcard import create_agent_card
 from agent.push.types import (
     DeleteTaskPushNotificationConfigRequest,
     DeleteTaskPushNotificationConfigResponse,
@@ -46,46 +37,12 @@ logger = structlog.get_logger(__name__)
 # Create router
 router = APIRouter()
 
-# Configuration will be loaded when needed
-
-# Agent card caching - Force cache invalidation for debugging
-_cached_agent_card: AgentCard | None = None
-_cached_extended_agent_card: AgentCard | None = None
-_cached_config_hash: str | None = None
 
 # Task storage
 task_storage: dict[str, dict[str, Any]] = {}
 
 # Request handler instance management
 _request_handler: DefaultRequestHandler | None = None
-
-
-def _get_package_version(package_name: str) -> str:
-    """Get the version of a package from metadata.
-
-    Args:
-        package_name: Name of the package to get version for
-
-    Returns:
-        Package version string or "0.0.0" if not found
-    """
-    try:
-        return importlib.metadata.version(package_name)
-    except importlib.metadata.PackageNotFoundError:
-        logger.warning(f"Package '{package_name}' not found in metadata")
-        return "0.0.0"
-    except Exception as e:
-        logger.warning(f"Failed to get version for package '{package_name}': {e}")
-        return "0.0.0"
-
-
-def _clear_agent_card_cache() -> None:
-    """Clear the agent card cache to force regeneration."""
-    global _cached_agent_card, _cached_extended_agent_card, _cached_config_hash
-    _cached_agent_card = None
-    _cached_extended_agent_card = None
-    _cached_config_hash = None
-    logger.debug("Agent card cache cleared")
 
 
 def set_request_handler_instance(handler: DefaultRequestHandler):
@@ -97,288 +54,6 @@ def get_request_handler() -> DefaultRequestHandler:
     if _request_handler is None:
         raise RuntimeError("Request handler not initialized")
     return _request_handler
-
-
-def _get_mcp_skills_for_agent_card() -> list[AgentSkill]:
-    """Convert registered MCP capabilities to AgentSkill objects.
-
-    Only includes MCP tools from servers with expose_as_skills: true.
-
-    Returns:
-        List of AgentSkill objects representing MCP tools
-    """
-    from agent.capabilities.manager import get_mcp_capabilities
-    from agent.services.config import ConfigurationManager
-
-    mcp_skills = []
-    try:
-        # Get MCP server configuration to check expose_as_skills flags
-        config_manager = ConfigurationManager()
-        config = config_manager.config
-
-        mcp_config = config.get("mcp", {})
-        if not mcp_config.get("enabled"):
-            return mcp_skills
-        servers = mcp_config.get("servers", [])
-
-        # Create a mapping of server names to expose_as_skills setting
-        server_expose_flags = {}
-        for server in servers:
-            # TODO: Pydantic validation for server config
-            server_name = server.get("name")
-            expose_flag = server.get("expose_as_skills", False)
-
-            server_expose_flags[server_name] = expose_flag
-
-        mcp_capabilities = get_mcp_capabilities()
-
-        # If no capabilities are available, return empty list
-        if not mcp_capabilities:
-            return mcp_skills
-
-        for capability_id, capability_info in mcp_capabilities.items():
-            # Only include capabilities from servers with expose_as_skills: true
-            server_name = capability_info.server_name
-
-            # Add server name to capability ID for uniqueness
-            name = f"{server_name}:{capability_id}" if server_name else capability_id
-
-            if server_expose_flags.get(server_name, False):
-                logger.debug(
-                    f"Including capability '{capability_id}' in AgentCard (server '{server_name}' has expose_as_skills=true)"
-                )
-
-                # Convert MCPCapabilityInfo to AgentSkill
-                skill = AgentSkill(
-                    id=capability_id,
-                    name=name,
-                    description=capability_info.description,
-                    inputModes=["text"],
-                    outputModes=["text"],
-                    tags=["mcp", capability_info.server_name] if capability_info.server_name else ["mcp"],
-                )
-                mcp_skills.append(skill)
-            else:
-                logger.debug(
-                    f"Skipping capability '{capability_id}' (server '{server_name}' has expose_as_skills={server_expose_flags.get(server_name, False)})"
-                )
-
-        if mcp_skills:
-            logger.debug(
-                f"Added {len(mcp_skills)} MCP tools as AgentCard skills from servers with expose_as_skills=true"
-            )
-
-    except Exception as e:
-        logger.error(f"Failed to get MCP capabilities for AgentCard: {e}")
-        import traceback
-
-        logger.error(f"Traceback: {traceback.format_exc()}")
-
-    return mcp_skills
-
-
-def create_agent_card(extended: bool = False) -> AgentCard:
-    """Create agent card with current configuration.
-
-    Args:
-        extended: If True, include plugins with visibility="extended" in addition to public plugins
-    """
-    import hashlib
-
-    global _cached_agent_card, _cached_extended_agent_card, _cached_config_hash
-
-    # Get configuration from the cached ConfigurationManager
-    config_manager = ConfigurationManager()
-    config = config_manager.config
-
-    # Create a hash of the configuration to detect changes
-    config_str = str(sorted(config.items()))
-    # Bandit issue: B324 - Using hashlib.md5() is acceptable here for caching purposes
-    current_config_hash = hashlib.md5(config_str.encode()).hexdigest()  # nosec
-
-    # Check if we can use cached version
-    if _cached_config_hash == current_config_hash:
-        if extended and _cached_extended_agent_card is not None:
-            logger.debug("Using cached extended AgentCard")
-            return _cached_extended_agent_card
-        elif not extended and _cached_agent_card is not None:
-            logger.debug("Using cached AgentCard")
-            return _cached_agent_card
-
-    # Cache miss - regenerate agent card
-    agent_info = config.get("agent", {})
-    plugins = config.get("plugins", [])
-
-    # Only log plugins when actually regenerating (cache miss)
-    logger.debug(f"Regenerating agent card - loaded {len(plugins)} plugins from config")
-
-    # Convert plugins to A2A Skill format based on visibility
-    agent_skills = []
-    has_extended_plugins = False
-
-    # Add MCP tools as skills
-    agent_skills.extend(_get_mcp_skills_for_agent_card())
-
-    # Get plugin information from the plugin registry
-    from agent.plugins.manager import get_plugin_registry
-
-    registry = get_plugin_registry()
-    if registry and registry.plugins:
-        # Create a lookup for plugin configurations by their ID for efficient access
-        plugins_by_id = {p.get("plugin_id"): p for p in plugins if p.get("plugin_id")}
-
-        # Get loaded plugins from the registry's plugins attribute
-        for plugin_id, _plugin_instance in registry.plugins.items():
-            plugin_config = plugins_by_id.get(plugin_id)
-
-            if plugin_config:
-                plugin_visibility = plugin_config.get("visibility", "public")
-
-                # Track if any extended plugins exist
-                if plugin_visibility == "extended":
-                    has_extended_plugins = True
-
-                # Include plugin in card based on visibility and card type
-                if plugin_visibility == "public" or (extended and plugin_visibility == "extended"):
-                    agent_skill = AgentSkill(
-                        id=plugin_id,
-                        name=plugin_config.get("name") or plugin_id,
-                        description=plugin_config.get("description") or f"Plugin {plugin_id}",
-                        inputModes=[plugin_config.get("input_mode", "text")],
-                        outputModes=[plugin_config.get("output_mode", "text")],
-                        tags=plugin_config.get("tags", ["general"]),
-                    )
-                    agent_skills.append(agent_skill)
-
-    # Create capabilities object with extensions
-    extensions = []
-
-    # Add MCP extension if enabled
-    mcp_config = config.get("mcp", {})
-    if mcp_config.get("enabled") and mcp_config.get("server", {}).get("enabled"):
-        mcp_extension = AgentExtension(
-            uri="https://modelcontextprotocol.io/mcp/1.0",
-            description="Agent supports MCP for tool sharing and collaboration",
-            params={
-                "endpoint": "/mcp",
-                "transport": "http",
-                "authentication": "api_key",
-            },
-            required=False,
-        )
-        extensions.append(mcp_extension)
-
-    pushNotifications = config.get("push_notifications", {})
-    state_management = config.get("state_management", {})
-
-    capabilities = AgentCapabilities(
-        streaming=True,  # this is always true, as we support non-streaming and streaming methods
-        push_notifications=pushNotifications.get("enabled", False),
-        state_transition_history=state_management.get("enabled", False),
-        extensions=extensions if extensions else None,
-    )
-
-    # Create security schemes based on configuration
-    security_config = config.get("security", {})
-    security_schemes = {}
-    security_requirements = []
-
-    # Get protocol version from a2a-sdk package
-    protocol_version = _get_package_version("a2a-sdk")
-    if security_config.get("enabled", False):
-        auth_type = security_config.get("type", "api_key")
-
-        if auth_type == "api_key":
-            # API Key authentication
-            api_key_scheme = APIKeySecurityScheme.model_validate(
-                {
-                    "name": "X-API-Key",
-                    "description": "API key for authentication",
-                    "in": "header",  # <- use the JSON alias
-                    "type": "apiKey",
-                }
-            )
-            security_schemes["X-API-Key"] = api_key_scheme.model_dump(by_alias=True)
-            security_requirements.append({"X-API-Key": []})
-
-        elif auth_type == "bearer":
-            # Bearer Token authentication
-            bearer_scheme = HTTPAuthSecurityScheme(
-                scheme="bearer", description="Bearer token for authentication", type="http"
-            )
-            security_schemes["BearerAuth"] = bearer_scheme.model_dump(by_alias=True)
-            security_requirements.append({"BearerAuth": []})
-
-        elif auth_type == "oauth2":
-            # OAuth2 Bearer Token authentication
-            oauth2_config = security_config.get("oauth2", {})
-            required_scopes = oauth2_config.get("required_scopes", [])
-
-            oauth2_scheme = HTTPAuthSecurityScheme(
-                scheme="bearer",
-                description="OAuth2 Bearer token for authentication",
-                type="http",
-                bearerFormat="JWT",  # Indicate JWT format for OAuth2
-            )
-            security_schemes["OAuth2"] = oauth2_scheme.model_dump(by_alias=True)
-            security_requirements.append({"OAuth2": required_scopes})
-
-    # Create the official AgentCard
-    # Get version from package metadata, fallback to default
-    package_version = _get_package_version("agentup")
-
-    # Create signatures object only if we have actual signature data
-    signatures = None
-    signature_header = agent_info.get("signature_header")
-    signature_protected = agent_info.get("signature_protected")
-    signature_value = agent_info.get("signature")
-
-    if signature_header and signature_protected and signature_value:
-        signatures = AgentCardSignature(
-            header=signature_header,
-            protected=signature_protected,
-            signature=signature_value,
-        )
-
-    agent_card = AgentCard(
-        protocol_version=protocol_version,
-        name=agent_info.get("name", config.get("project_name", "Agent")),
-        description=agent_info.get("description", config.get("description", "AI Agent")),
-        url=agent_info.get("url", config.get("url", "http://localhost:8000")),
-        preferred_transport="JSONRPC!",
-        provider=AgentProvider(
-            organization=agent_info.get("provider_organization", "AgentUp"),
-            url=agent_info.get("provider_url", "http://localhost:8000"),
-        ),
-        icon_url=agent_info.get(
-            "icon_url",
-            config.get(
-                "icon_url", "https://raw.githubusercontent.com/RedDotRocket/AgentUp/refs/heads/main/assets/icon.png"
-            ),
-        ),
-        version=agent_info.get("version", package_version),
-        documentationUrl=agent_info.get(
-            "documentation_url",
-            config.get("documentation_url", "https://docs.agentup.dev"),
-        ),
-        capabilities=capabilities,
-        security=security_requirements if security_requirements else None,
-        defaultInputModes=["text"],
-        defaultOutputModes=["text"],
-        skills=agent_skills,
-        securitySchemes=security_schemes if security_schemes else None,
-        signatures=signatures,
-        supportsAuthenticatedExtendedCard=has_extended_plugins,
-    )
-
-    # Update cache
-    _cached_config_hash = current_config_hash
-    if extended:
-        _cached_extended_agent_card = agent_card
-    else:
-        _cached_agent_card = agent_card
-
-    return agent_card
 
 
 @router.get("/task/{task_id}/status")
@@ -645,13 +320,6 @@ async def jsonrpc_endpoint(
         )
 
 
-# Error handlers (to be registered with FastAPI app)
-async def jsonrpc_error_handler(request: Request, exc: JSONRPCError):
-    return JSONResponse(
-        status_code=400, content={"error": {"code": exc.code, "message": exc.message, "data": exc.data}}
-    )
-
-
 # Handler functions for new push notification methods
 async def handle_get_push_notification_config(request: GetTaskPushNotificationConfigRequest):
     """
@@ -758,7 +426,6 @@ async def handle_delete_push_notification_config(
 # Export router and handlers
 __all__ = [
     "router",
-    "jsonrpc_error_handler",
     "set_request_handler_instance",
     "get_request_handler",
     "handle_list_push_notification_configs",

--- a/src/agent/config/a2a.py
+++ b/src/agent/config/a2a.py
@@ -7,9 +7,6 @@ for JSON-RPC communication between agents.
 
 from __future__ import annotations
 
-from abc import ABC
-from typing import Any
-
 # Import official A2A types
 from a2a.types import (
     AgentCapabilities,
@@ -34,15 +31,6 @@ from a2a.types import (
     TaskStatus,
     TextPart,
 )
-from pydantic import BaseModel, Field
-
-
-class JSONRPCError(Exception):
-    def __init__(self, code: int, message: str, data: Any = None):
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.data = data
 
 
 class TaskNotFoundError(Exception):
@@ -92,44 +80,6 @@ def get_error_code_for_exception(exception_type: type[Exception]) -> int | None:
     return A2A_ERROR_CODE_MAP.get(exception_type)
 
 
-def create_jsonrpc_error_from_exception(exception: Exception, request_id: Any = None) -> dict[str, Any]:
-    """Create a JSON-RPC error response from an exception.
-
-    Args:
-        exception: The exception instance
-        request_id: The JSON-RPC request ID
-
-    Returns:
-        A JSON-RPC error response dictionary
-    """
-    error_code = get_error_code_for_exception(type(exception))
-
-    if error_code is None:
-        # Default to internal error for unknown exceptions
-        error_code = -32603
-
-    return {
-        "jsonrpc": "2.0",
-        "error": {"code": error_code, "message": str(exception), "data": {"exception_type": type(exception).__name__}},
-        "id": request_id,
-    }
-
-
-# NOTE: Configuration models have been moved to model.py
-# This file now focuses solely on A2A protocol integration
-
-
-class BaseAgent(BaseModel, ABC):
-    model_config = {
-        "arbitrary_types_allowed": True,
-        "extra": "allow",
-    }
-
-    agent_name: str = Field(description="The name of the agent.")
-    description: str = Field(description="A brief description of the agent's purpose.")
-    content_types: list[str] = Field(description="Supported content types.")
-
-
 # Re-export A2A types and error handling for convenience
 __all__ = [
     # A2A protocol types
@@ -155,7 +105,6 @@ __all__ = [
     "TaskState",
     "TaskStatus",
     # A2A JSON-RPC exceptions
-    "JSONRPCError",
     "TaskNotFoundError",
     "TaskNotCancelableError",
     "PushNotificationNotSupportedError",
@@ -165,7 +114,4 @@ __all__ = [
     # A2A error handling utilities
     "A2A_ERROR_CODE_MAP",
     "get_error_code_for_exception",
-    "create_jsonrpc_error_from_exception",
-    # A2A base classes
-    "BaseAgent",
 ]

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -8,7 +8,6 @@ for type safety and validation.
 from __future__ import annotations
 
 import os
-from abc import ABC
 from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
@@ -20,7 +19,7 @@ from ..types import ConfigDict as ConfigDictType
 from ..types import FilePath, LogLevel, ModulePath, ServiceName, ServiceType, Version
 
 
-class BaseAgent(BaseModel, ABC):
+class BaseAgent(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "extra": "allow",

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -8,6 +8,7 @@ for type safety and validation.
 from __future__ import annotations
 
 import os
+from abc import ABC
 from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
@@ -17,6 +18,17 @@ from pydantic_settings import BaseSettings
 
 from ..types import ConfigDict as ConfigDictType
 from ..types import FilePath, LogLevel, ModulePath, ServiceName, ServiceType, Version
+
+
+class BaseAgent(BaseModel, ABC):
+    model_config = {
+        "arbitrary_types_allowed": True,
+        "extra": "allow",
+    }
+
+    agent_name: str = Field(description="The name of the agent.")
+    description: str = Field(description="A brief description of the agent's purpose.")
+    content_types: list[str] = Field(description="Supported content types.")
 
 
 class EnvironmentVariable(BaseModel):
@@ -591,6 +603,7 @@ def expand_env_vars(value: Any) -> Any:
 # Re-export key models
 __all__ = [
     "AgentConfig",
+    "BaseAgent",
     "ServiceConfig",
     "LoggingConfig",
     "APIConfig",

--- a/src/agent/core/executor.py
+++ b/src/agent/core/executor.py
@@ -24,7 +24,7 @@ from a2a.utils import (
 )
 from a2a.utils.errors import ServerError
 
-from agent.config.a2a import BaseAgent
+from agent.config.model import BaseAgent
 
 logger = structlog.get_logger(__name__)
 


### PR DESCRIPTION
- Let a2a library handle JSON-RPC errors as designed
- Remove custom jsonrpc_error_handler function and related imports
- Move AgentCard out of routes to keep it to only endpoint handlers
