### PR TITLE
docs: remove outdated root cache config reference (Fixes #252)

### DIFF
--- a/docs/middleware/rate-limiting.md
+++ b/docs/middleware/rate-limiting.md
@@ -1,11 +1,14 @@
 # AgentUp Rate-Limiting
 
-As with all middleware in AgentUp, there is an option to apply globally and
-then override for specific plugins, but also network specific
+Rate limiting in AgentUp is managed through **middleware**.  
+You can apply it globally (network-level) or override for specific plugins.  
+Root-level configuration is no longer supported — use middleware only.  
+
+---
 
 ## Network-Level Rate Limiting (FastAPI Middleware)
 
-Rate limiting on AgentUp's FastAPI middleware is exposed via AgentUp's `agentup.yml`
+Rate limiting on AgentUp's FastAPI middleware is exposed via `agentup.yml`:
 
 ```yaml
 rate_limiting:
@@ -14,49 +17,47 @@ rate_limiting:
     "/": {"rpm": 100, "burst": 120}
     "/mcp": {"rpm": 60, "burst": 150}
 ```
-| Aspect | Description |
-|--------|-------------|
-| Scope | All HTTP requests to specific endpoints |
-| Applied | Before requests reach any plugin code |
-| Purpose | Network-level protection |
 
-The applied Rate Limiting, can be seen when starting an Agent in DEBUG mode, for example:
+**Details:**
 
-```
+| Aspect     | Description                                |
+|------------|--------------------------------------------|
+| Scope      | All HTTP requests to specific endpoints    |
+| Applied    | Before requests reach any plugin code      |
+| Purpose    | Network-level protection                   |
+
+The applied Rate Limiting can be seen when starting an Agent in **DEBUG** mode, for example:
+
+```text
 2025-07-28 19:43:02 [DEBUG] Network rate limiting middleware initialized endpoint_limits={'/': {'rpm': 100, 'burst': 120}, '/mcp': {'rpm': 50, 'burst': 60}, '/health': {'rpm': 200, 'burst': 240}, '/status': {'rpm': 60, 'burst': 72}, 'default': {'rpm': 60, 'burst': 72}}
-
-## Root-Level Middleware (Global Plugin Middleware)
-
-Root-level Middleware is applied universally to all plugins (unless as below, over-ridden)
-
-```yaml
-  middleware:
-    - name: rate_limited
-      enabled: true
-      params:
-        requests_per_minute: 10
 ```
 
-| Aspect | Description |
-|--------|-------------|
-| Scope | ALL plugins/capabilities by default |
-| Applied | To every plugin function unless overridden |
-| Purpose | Organization-wide baseline policies |
+---
 
 ## Plugin-Specific Override (Per-Plugin Middleware)
+
+You can override the global middleware for a specific plugin by adding a plugin-level override in `agentup.yml`:
 
 ```yaml
 plugins:
 - plugin_id: name
     middleware_override:
     - name: rate_limited
-        params:
+      params:
         requests_per_minute: 10
 ```
 
-| Aspect | Description |
-|--------|-------------|
-| Scope | ONLY that specific plugin |
-| Applied | Replaces global middleware for that plugin |
-| Purpose | Fine-tuned control per plugin |
+**Details:**
 
+| Aspect     | Description                                |
+|------------|--------------------------------------------|
+| Scope      | ONLY that specific plugin                  |
+| Applied    | Replaces global middleware for that plugin |
+| Purpose    | Fine-tuned control per plugin              |
+
+---
+
+## ⚠️ Note on Root-Level Configuration
+
+Previous versions of AgentUp allowed **root-level rate limiting config**.  
+This is no longer supported — all configuration must now be done through **middleware**.


### PR DESCRIPTION
---
name: 🛠️ Pull Request
about: Submit a code contribution to AgentUp
title: "[PR]: docs: remove outdated root cache config reference (Fixes #252)"
labels: 'documentation'
assignees: ''
---

## 📝 Description

This PR fixes documentation issue #252.

The docs previously referenced a root-level cache/rate-limiting configuration, which is no longer supported.  
All configuration must now be done via **middleware** (network-level or plugin-specific overrides).  

---

## 🔍 Related Issues

Closes #252

---

## 🧪 Testing

- Verified markdown renders properly on GitHub (tables + code blocks render cleanly)  
- Confirmed the outdated section was removed and note added about middleware-only config  

- [x] Security Tests pass (Bandit) — *N/A (docs only)*  
- [x] Unit tests pass — *N/A (docs only)*  
- [x] Manual testing completed — *Verified visual rendering*  

---

## 🧾 Changes Checklist

- [x] I’ve read the [contributing guidelines](../CONTRIBUTING.md)  
- [x] My code follows the AgentUp code style  
- [ ] I’ve added tests (not applicable for documentation-only changes)  
- [x] I’ve updated documentation  
- [ ] I've added information on any changes to `agentup.yml` required (N/A)  

---

## 🧩 Additional Notes

- This is a **documentation-only change** — no functional code was modified.  
- Added a clarification note at the bottom of the file to prevent future confusion.  
