### PR TITLE
Feat: rename 'plugin create' to 'plugin init'

### DIFF
--- a/docs/agentup-development/index.md
+++ b/docs/agentup-development/index.md
@@ -47,7 +47,7 @@ When developing plugins while working on AgentUp source:
 ```bash
 # Create plugin in separate location
 cd ~/my-plugins  # Or any directory outside AgentUp source
-uv run --directory /path/to/AgentUp agentup plugin create my-plugin
+uv run --directory /path/to/AgentUp agentup plugin init my-plugin
 
 # Install plugin into AgentUp's venv for testing
 cd my-plugin
@@ -66,7 +66,7 @@ export AGENTUP_PLUGIN_PATHS="$HOME/my-plugins:./local-plugins"
 
 # Create and test plugins without installation
 mkdir -p local-plugins
-uv run agentup plugin create local-plugins/test-plugin
+uv run agentup plugin init local-plugins/test-plugin
 
 # Plugin auto-discovered from AGENTUP_PLUGIN_PATHS
 uv run agentup run
@@ -110,7 +110,7 @@ pip install agentup
 
 # Create plugin anywhere
 mkdir -p ~/my-plugins && cd ~/my-plugins
-agentup plugin create weather-plugin --template ai
+agentup plugin init weather-plugin --template ai
 cd weather-plugin
 
 # Install for development (same environment as AgentUp)
@@ -143,7 +143,7 @@ cd AgentUp && uv sync
 
 # Create plugin in separate directory
 cd ~/my-plugins
-uv run --directory /path/to/AgentUp agentup plugin create my-plugin
+uv run --directory /path/to/AgentUp agentup plugin init my-plugin
 cd my-plugin
 
 # Install into AgentUp's development environment

--- a/docs/agentup-development/release.md
+++ b/docs/agentup-development/release.md
@@ -211,7 +211,7 @@ agentup init my-agent
 Plugin templates also get the correct version:
 
 ```bash
-agentup plugin create my-plugin
+agentup plugin init my-plugin
 # Generated files use current AgentUp version automatically
 ```
 

--- a/docs/plugin-development/ai-functions.md
+++ b/docs/plugin-development/ai-functions.md
@@ -25,7 +25,7 @@ Let's build a calculator plugin with AI functions:
 ### Step 1: Basic Plugin Setup
 
 ```bash
-agentup plugin create calculator-plugin
+agentup plugin init calculator-plugin
 cd calculator-plugin
 ```
 

--- a/docs/plugin-development/cli-reference.md
+++ b/docs/plugin-development/cli-reference.md
@@ -18,7 +18,7 @@ The new CLI includes advanced security features:
 
 ## Important: Working Directory Context
 
-**Plugin Creation Commands** (`agentup plugin create`):
+**Plugin Creation Commands** (`agentup plugin init`):
 - Can be run from **any directory** on your system
 - Creates a new plugin project directory
 - Does **NOT** require an existing agent project
@@ -31,7 +31,7 @@ The new CLI includes advanced security features:
 ```bash
 # Plugin creation - run from anywhere
 cd ~/my-projects/
-agentup plugin create weather-plugin
+agentup plugin init weather-plugin
 
 # Plugin management - run from anywhere  
 agentup plugin install weather-plugin --require-trusted
@@ -375,14 +375,14 @@ Total Capabilities: 12
 
 ---
 
-### `agentup plugin create`
+### `agentup plugin init`
 
 Create a new plugin for development using the modern decorator system.
 
 #### Usage
 
 ```bash
-agentup plugin create [NAME] [OPTIONS]
+agentup plugin init [NAME] [OPTIONS]
 ```
 
 #### Arguments
@@ -403,7 +403,7 @@ agentup plugin create [NAME] [OPTIONS]
 
 **Interactive creation:**
 ```bash
-agentup plugin create
+agentup plugin init
 ```
 
 The CLI will prompt for:
@@ -415,12 +415,12 @@ The CLI will prompt for:
 
 **Quick creation with template:**
 ```bash
-agentup plugin create weather-plugin --template ai
+agentup plugin init weather-plugin --template ai
 ```
 
 **Specify output directory:**
 ```bash
-agentup plugin create my-plugin --output-dir ./plugins/my-plugin
+agentup plugin init my-plugin --output-dir ./plugins/my-plugin
 ```
 
 #### Generated Structure
@@ -593,7 +593,7 @@ agentup plugin refresh --plugin-id weather-plugin
 
 **1. Create a new plugin:**
 ```bash
-agentup plugin create my-awesome-plugin --template ai
+agentup plugin init my-awesome-plugin --template ai
 cd my-awesome-plugin
 ```
 

--- a/docs/plugin-development/development.md
+++ b/docs/plugin-development/development.md
@@ -70,7 +70,7 @@ Let's build a comprehensive weather plugin that demonstrates all major features:
 ### Step 1: Project Setup
 
 ```bash
-agentup plugin create weather-plugin
+agentup plugin init weather-plugin
 cd weather-plugin
 ```
 

--- a/docs/plugin-development/getting-started.md
+++ b/docs/plugin-development/getting-started.md
@@ -16,7 +16,7 @@ AgentUp plugins are **standalone Python packages** that can be created anywhere 
 ```bash
 # You can create plugins in any directory
 cd ~/my-projects/          # Or any directory you prefer
-agentup plugin create time-plugin
+agentup plugin init time-plugin
 
 # This creates a new plugin directory with the modern decorator system
 cd time-plugin/
@@ -42,7 +42,7 @@ Let's create a plugin that provides time and date information:
 
 ```bash
 # Run this from any directory where you want to create the plugin
-agentup plugin create time-plugin
+agentup plugin init time-plugin
 # Note: By default, this creates an AI-enabled plugin. Use --template direct for a basic plugin
 ```
 

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -20,10 +20,10 @@ Plugins can be created anywhere - you don't need to be inside an agent project:
 
 ```bash
 # Create a new plugin with interactive prompts (run from any directory)
-agentup plugin create
+agentup plugin init
 
 # Or specify details directly
-agentup plugin create weather-plugin --template ai
+agentup plugin init weather-plugin --template ai
 
 # This creates a new directory with your plugin
 cd weather-plugin/

--- a/docs/plugin-development/testing.md
+++ b/docs/plugin-development/testing.md
@@ -18,7 +18,7 @@ AgentUp plugins using the new decorator-based system should be tested at multipl
 
 ### Basic Test Structure
 
-When you create a plugin with `agentup plugin create`, you get a comprehensive test structure:
+When you create a plugin with `agentup plugin init`, you get a comprehensive test structure:
 
 ```
 my-plugin/

--- a/src/agent/cli/cli_utils.py
+++ b/src/agent/cli/cli_utils.py
@@ -1,5 +1,8 @@
 import os
 import tarfile
+from collections import OrderedDict
+
+import click
 
 
 def _is_within_directory(base_dir: str, target_path: str) -> bool:
@@ -22,3 +25,16 @@ def safe_extract(tar: tarfile.TarFile, path: str = ".", members=None) -> None:
             raise Exception(f"Path traversal detected in tar member: {member.name!r}")
     # Bandit: I am doing this to make you happy!
     tar.extractall(path=path, members=members)  # nosec
+
+
+class OrderedGroup(click.Group):
+    def __init__(self, name=None, commands=None, **attrs):
+        super().__init__(name=name, commands=commands, **attrs)
+        self.commands = OrderedDict()
+
+    def add_command(self, cmd, name=None):
+        name = name or cmd.name
+        self.commands[name] = cmd
+
+    def list_commands(self, ctx):
+        return self.commands.keys()

--- a/src/agent/cli/commands/init_agent.py
+++ b/src/agent/cli/commands/init_agent.py
@@ -32,14 +32,58 @@ def init_agent(
     """
     print_header("AgentUp Agent Creator", "Create your AI agent")
 
+    # Initial setup
+    if config:
+        project_config = {"base_config": Path(config)}
+        output_dir = output_dir or Path.cwd() / "new_agent"  # Use a default output dir if not provided
+        if not name:
+            click.echo("Warning: Agent name will be read from config file.", err=True)
+    else:
+        project_config, output_dir = _prompt_for_basic_config(name, version, quick, output_dir)
+        if output_dir is None:
+            return
+
+    # Configuration
+    if not config:
+        _prompt_for_features(project_config, quick, no_git)
+
+    # Generate the project
+    click.echo(f"\n{click.style('Creating project...', fg='yellow')}")
+    try:
+        generator = ProjectGenerator(output_dir, project_config)
+        generator.generate()
+
+        _handle_git_initialization(output_dir, no_git)
+
+        print_success_footer(
+            "✓ Project created successfully!",
+            location=str(output_dir),
+            docs_url="https://docs.agentup.dev/getting-started/first-agent/",
+        )
+        click.secho("\nNext steps:", fg="white", bold=True)
+        click.echo(f"  1. cd {output_dir.name}")
+        click.echo("  2. uv sync                 # Install dependencies")
+        click.echo("  3. uv add <plugin_name>    # Add AgentUp plugins")
+        click.echo("  4. agentup plugin sync     # Sync plugins with config")
+        click.echo("  5. agentup run             # Start development server")
+
+    except Exception as e:
+        print_error(str(e))
+        return
+
+
+# Helper functions
+def _prompt_for_basic_config(
+    name: str | None, version: str | None, quick: bool, output_dir: str | None
+) -> tuple[dict[str, Any], Path | None]:
+    """Prompts for basic project configuration and returns the config and output path."""
     project_config = {}
 
     if not name:
         name = questionary.text("Agent name:", style=custom_style, validate=lambda x: len(x.strip()) > 0).ask()
         if not name:
             click.echo("Cancelled.")
-            return
-
+            return {}, None
     project_config["name"] = name
 
     if not output_dir:
@@ -53,128 +97,85 @@ def init_agent(
         if quick:
             # In quick mode, automatically overwrite if directory exists
             click.echo(f"Directory {output_dir} already exists. Continuing in quick mode...")
-        else:
-            if not questionary.confirm(
-                f"Directory {output_dir} already exists. Continue?",
-                default=False,
-                style=custom_style,
-            ).ask():
-                click.echo("Cancelled.")
-                return
+        elif not questionary.confirm(
+            f"Directory {output_dir} already exists. Continue?", default=False, style=custom_style
+        ).ask():
+            click.echo("Cancelled.")
+            return {}, None
 
     if quick:
         project_config["description"] = f"AI Agent {name} Project."
         project_config["version"] = version or "0.0.1"
-        # Include default checked features in quick mode
-        default_features = [choice.value for choice in get_feature_choices() if choice.checked]
-        project_config["features"] = default_features
-        project_config["feature_config"] = {}
     else:
         description = questionary.text("Description:", default=f"AI Agent {name} Project.", style=custom_style).ask()
         project_config["description"] = description
-
-        project_config["features"] = []
-
         if not version:
             version = questionary.text("Version:", default="0.0.1", style=custom_style).ask()
-
         project_config["version"] = version
 
-        if not no_git:
-            project_config["author_info"] = get_git_author_info()
+    return project_config, output_dir
 
-        if questionary.confirm("Would you like to customize the features?", default=False, style=custom_style).ask():
-            # Get all available feature choices
-            feature_choices = get_feature_choices()
 
-            # All features unchecked by default
-            for choice in feature_choices:
-                choice.checked = False
+def _prompt_for_features(project_config: dict[str, Any], quick: bool, no_git: bool):
+    """Prompts for and configures advanced features."""
+    if not no_git:
+        project_config["author_info"] = get_git_author_info()
 
-            # Let user modify selection
-            selected_features = questionary.checkbox(
-                "Select features to include:", choices=feature_choices, style=custom_style
-            ).ask()
-
-            if selected_features is not None:  # User didn't cancel
-                # Configure detailed options for selected features
-                feature_config = configure_features(selected_features)
-                project_config["features"] = selected_features
-                project_config["feature_config"] = feature_config
-
-    # Configure AI provider if 'ai_provider' is in features
-    final_features = project_config.get("features", [])
-    if "ai_provider" in final_features:
-        if quick:
-            # Default to OpenAI in quick mode
-            project_config["ai_provider_config"] = {"provider": "openai"}
-        else:
-            ai_provider_choice = questionary.select(
-                "Please select an AI Provider:",
-                choices=[
-                    questionary.Choice("OpenAI", value="openai"),
-                    questionary.Choice("Anthropic", value="anthropic"),
-                    questionary.Choice("Ollama", value="ollama"),
-                ],
-                style=custom_style,
-            ).ask()
-
-            if ai_provider_choice:
-                project_config["ai_provider_config"] = {"provider": ai_provider_choice}
-
-    # Configure external services if 'services' is in features (Database, Cache only)
-    if "services" in final_features:
-        if quick:
-            # Default to no external services in quick mode
-            project_config["services"] = []
-        else:
-            service_choices = [
-                questionary.Choice("Valkey", value="valkey"),
-                questionary.Choice("Custom API", value="custom"),
-            ]
-
-            selected = questionary.checkbox(
-                "Select external services:", choices=service_choices, style=custom_style
-            ).ask()
-
-            project_config["services"] = selected if selected else []
-
-    # Use existing config if provided
-    if config:
-        project_config["base_config"] = Path(config)
-
-    # Generate project
-    click.echo(f"\n{click.style('Creating project...', fg='yellow')}")
-
-    try:
-        generator = ProjectGenerator(output_dir, project_config)
-        generator.generate()
-
-        # Initialize git repository unless --no-git flag is used
-        if not no_git:
-            click.echo(f"{click.style('Initializing git repository...', fg='yellow')}")
-            success, error = initialize_git_repo(output_dir)
-            if success:
-                click.echo(f"{click.style('Git repository initialized', fg='green')}")
-            else:
-                click.echo(f"{click.style(f'  Warning: Could not initialize git repository: {error}', fg='yellow')}")
-
-        print_success_footer(
-            "✓ Project created successfully!",
-            location=str(output_dir),
-            docs_url="https://docs.agentup.dev/getting-started/first-agent/",
-        )
-
-        click.secho("\nNext steps:", fg="white", bold=True)
-        click.echo(f"  1. cd {output_dir.name}")
-        click.echo("  2. uv sync                # Install dependencies")
-        click.echo("  3. uv add <plugin_name>   # Add AgentUp plugins")
-        click.echo("  4. agentup plugin sync    # Sync plugins with config")
-        click.echo("  5. agentup run            # Start development server")
-
-    except Exception as e:
-        print_error(str(e))
+    if quick:
+        default_features = [choice.value for choice in get_feature_choices() if choice.checked]
+        project_config["features"] = default_features
+        project_config["feature_config"] = {}
+        project_config["ai_provider_config"] = {"provider": "openai"}
+        project_config["services"] = []
         return
+
+    # Standard mode
+    if questionary.confirm("Would you like to customize the features?", default=False, style=custom_style).ask():
+        feature_choices = get_feature_choices()
+        for choice in feature_choices:
+            choice.checked = False
+
+        selected_features = questionary.checkbox(
+            "Select features to include:", choices=feature_choices, style=custom_style
+        ).ask()
+        if selected_features is not None:
+            feature_config = configure_features(selected_features)
+            project_config["features"] = selected_features
+            project_config["feature_config"] = feature_config
+
+    # Configure AI provider
+    if "ai_provider" in project_config.get("features", []):
+        ai_provider_choice = questionary.select(
+            "Please select an AI Provider:",
+            choices=[
+                questionary.Choice("OpenAI", value="openai"),
+                questionary.Choice("Anthropic", value="anthropic"),
+                questionary.Choice("Ollama", value="ollama"),
+            ],
+            style=custom_style,
+        ).ask()
+        if ai_provider_choice:
+            project_config["ai_provider_config"] = {"provider": ai_provider_choice}
+
+    # Configure external services
+    if "services" in project_config.get("features", []):
+        service_choices = [
+            questionary.Choice("Valkey", value="valkey"),
+            questionary.Choice("Custom API", value="custom"),
+        ]
+        selected = questionary.checkbox("Select external services:", choices=service_choices, style=custom_style).ask()
+        project_config["services"] = selected if selected else []
+
+
+def _handle_git_initialization(output_dir: Path, no_git: bool):
+    """Initializes a Git repository in the output directory."""
+    if not no_git:
+        click.echo(f"{click.style('Initializing git repository...', fg='yellow')}")
+        success, error = initialize_git_repo(output_dir)
+        if success:
+            click.echo(f"{click.style('Git repository initialized', fg='green')}")
+        else:
+            click.echo(f"{click.style(f'Warning: Could not initialize git repository: {error}', fg='yellow')}")
 
 
 def configure_features(features: list) -> dict[str, Any]:
@@ -186,14 +187,10 @@ def configure_features(features: list) -> dict[str, Any]:
             questionary.Choice("Caching", value="cache", checked=True),
             questionary.Choice("Retry Logic", value="retry"),
         ]
-
         selected = questionary.checkbox(
             "Select middleware to include:", choices=middleware_choices, style=custom_style
         ).ask()
-
         config["middleware"] = selected if selected else []
-
-        # If cache is selected, ask for cache backend
         if "cache" in (selected or []):
             cache_backend_choice = questionary.select(
                 "Select cache backend:",
@@ -203,7 +200,6 @@ def configure_features(features: list) -> dict[str, Any]:
                 ],
                 style=custom_style,
             ).ask()
-
             config["cache_backend"] = cache_backend_choice
 
     if "state_management" in features:
@@ -216,7 +212,6 @@ def configure_features(features: list) -> dict[str, Any]:
             ],
             style=custom_style,
         ).ask()
-
         config["state_backend"] = state_backend_choice
 
     if "auth" in features:
@@ -229,10 +224,7 @@ def configure_features(features: list) -> dict[str, Any]:
             ],
             style=custom_style,
         ).ask()
-
         config["auth"] = auth_choice
-
-        # If OAuth2 is selected, ask for provider
         if auth_choice == "oauth2":
             oauth2_provider = questionary.select(
                 "Select OAuth2 provider:",
@@ -244,7 +236,6 @@ def configure_features(features: list) -> dict[str, Any]:
                 ],
                 style=custom_style,
             ).ask()
-
             config["oauth2_provider"] = oauth2_provider
 
     if "push_notifications" in features:
@@ -256,15 +247,12 @@ def configure_features(features: list) -> dict[str, Any]:
             ],
             style=custom_style,
         ).ask()
-
         config["push_backend"] = push_backend_choice
-
         validate_urls = questionary.confirm(
             "Enable webhook URL validation?",
             default=push_backend_choice == "valkey",
             style=custom_style,
         ).ask()
-
         config["push_validate_urls"] = validate_urls
 
     if "development" in features:
@@ -273,23 +261,18 @@ def configure_features(features: list) -> dict[str, Any]:
             default=False,
             style=custom_style,
         ).ask()
-
         config["development_enabled"] = dev_enabled
-
         if dev_enabled:
             filesystem_plugins = questionary.confirm(
                 "Enable filesystem plugin loading? (allows loading plugins from directories)",
                 default=True,
                 style=custom_style,
             ).ask()
-
             config["filesystem_plugins_enabled"] = filesystem_plugins
-
             if filesystem_plugins:
                 plugin_dir = questionary.text(
                     "Plugin directory path:", default="~/.agentup/plugins", style=custom_style
                 ).ask()
-
                 config["plugin_directory"] = plugin_dir
 
     if "mcp" in features:
@@ -306,26 +289,18 @@ def configure_features(features: list) -> dict[str, Any]:
             default=True,
             style=custom_style,
         ).ask()
-
         config["docker_enabled"] = docker_enabled
-
         if docker_enabled:
             docker_registry = questionary.text("Docker registry (optional):", default="", style=custom_style).ask()
-
             config["docker_registry"] = docker_registry if docker_registry else None
-
-        # Helm configuration
         helm_enabled = questionary.confirm(
             "Generate Helm charts for Kubernetes deployment?", default=True, style=custom_style
         ).ask()
-
         config["helm_enabled"] = helm_enabled
-
         if helm_enabled:
+            # Helm configuration
             helm_namespace = questionary.text(
                 "Default Kubernetes namespace:", default="default", style=custom_style
             ).ask()
-
             config["helm_namespace"] = helm_namespace
-
     return config

--- a/src/agent/cli/commands/plugin.py
+++ b/src/agent/cli/commands/plugin.py
@@ -1,16 +1,17 @@
 import click
 
 from ...utils.version import get_version
+from ..cli_utils import OrderedGroup
+from .plugin_info import config, info, list_plugins, validate
 
 # Import subcommands from specialized modules
-from .plugin_create import create
-from .plugin_info import config, info, list_plugins, validate
+from .plugin_init import init
 from .plugin_manage import add, reload, remove, sync
 
 # Export all commands and functions
 __all__ = [
     "plugin",
-    "create",
+    "init",
     "add",
     "remove",
     "sync",
@@ -23,14 +24,15 @@ __all__ = [
 ]
 
 
-@click.group("plugin", help="Manage plugins and their configurations.")
+@click.group("plugin", cls=OrderedGroup, help="Manage plugins and their configurations.")
+@click.version_option(version=get_version(), prog_name="agentup")
 def plugin():
     """Plugin management commands."""
     pass
 
 
 # Register all subcommands
-plugin.add_command(create)
+plugin.add_command(init)
 plugin.add_command(add)
 plugin.add_command(remove)
 plugin.add_command(sync)

--- a/src/agent/cli/commands/plugin_info.py
+++ b/src/agent/cli/commands/plugin_info.py
@@ -210,7 +210,7 @@ def list_plugins(verbose: bool, capabilities: bool, format: str, agentup_cfg: bo
             click.secho("No plugins found", fg="yellow")
             click.secho(
                 "\nTo create a plugin: "
-                + click.style("agentup plugin create ", fg="cyan")
+                + click.style("agentup plugin init ", fg="cyan")
                 + click.style("<plugin_name>", fg="blue")
             )
             click.secho(

--- a/src/agent/cli/commands/plugin_init.py
+++ b/src/agent/cli/commands/plugin_init.py
@@ -353,18 +353,18 @@ def init(
 
         def validate_email(email_str: str) -> bool | str:
             """Validator for questionary that returns True or error message."""
-            if not email.strip():
+            if not email_str.strip():
                 return True  # Allow empty email
 
             # Basic email validation
-            if " " in email:
+            if " " in email_str:
                 return "Email cannot contain spaces"
-            if "@" not in email:
+            if "@" not in email_str:
                 return "Email must contain @"
-            if email.count("@") != 1:
+            if email_str.count("@") != 1:
                 return "Email must contain exactly one @"
 
-            parts = email.split("@")
+            parts = email_str.split("@")
             if not parts[0] or not parts[1]:
                 return "Email must have text before and after @"
             if "." not in parts[1]:

--- a/src/agent/cli/main.py
+++ b/src/agent/cli/main.py
@@ -1,28 +1,15 @@
 import logging
 import os
-from collections import OrderedDict
 
 import click
 
 from ..utils.version import get_version
+from .cli_utils import OrderedGroup
 from .commands.deploy import deploy
 from .commands.init import init
 from .commands.plugin import plugin
 from .commands.run import run
 from .commands.validate import validate
-
-
-class OrderedGroup(click.Group):
-    def __init__(self, name=None, commands=None, **attrs):
-        super().__init__(name=name, commands=commands, **attrs)
-        self.commands = OrderedDict()
-
-    def add_command(self, cmd, name=None):
-        name = name or cmd.name
-        self.commands[name] = cmd
-
-    def list_commands(self, ctx):
-        return self.commands.keys()
 
 
 def setup_cli_logging():

--- a/src/agent/templates/README.md.j2
+++ b/src/agent/templates/README.md.j2
@@ -57,7 +57,7 @@ This agent runs from the AgentUp framework package.
 **Create a Local Plugin:**
 ```bash
 # Create plugin in the plugins directory
-agentup plugin create my-skill --output-dir plugins/
+agentup plugin init my-skill --output-dir plugins/
 
 # Install in development mode
 pip install -e plugins/my-skill

--- a/tests/test_cli/test_plugin_list.py
+++ b/tests/test_cli/test_plugin_list.py
@@ -124,7 +124,7 @@ class TestPluginListCommand:
             result = runner.invoke(list_plugins, [])
             assert result.exit_code == 0
             assert "No plugins found" in result.output
-            assert "agentup plugin create" in result.output
+            assert "agentup plugin init" in result.output
 
     def test_list_plugins_table_format(self, runner, mock_plugin_registry):
         """Test listing plugins in table format (default)."""


### PR DESCRIPTION
The 'create' command has been renamed to 'init' for consistency with other common CLI tools (e.g., 'git init' or 'npm init').

This change improves the user experience by aligning the command with a more intuitive and widely-recognized term for project setup.

In addition, this commit includes the following related CLI cleanup:

- Refactored logic to separate configuration prompting from project generation.
- Updated internal method names for clarity (e.g., '_prompt_for_features').
- Fixed syntax errors in the plugin command group decorator.
- Author and email gets auto pulled from git for plugin creation, otherwise is prompted
Closes #259 
---
name: 🛠️ Pull Request
about: Submit a code contribution to AgentUp
title: "[PR]: "
labels: ''
assignees: ''

---

## 📝 Description

Briefly describe what this pull request does and why it is needed.

---

## 🔍 Related Issues

Closes #issue_number or references related issues.

---

## 🧪 Testing

Explain how this has been tested or provide reproduction steps.

- [ ] Security Tests pass (Bandit)
- [ ] Unit tests pass
- [ ] Manual testing completed

---

## 🧾 Changes Checklist

- [ ] I’ve read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] My code follows the AgentUp code style
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] I've added information on any changes to `agentup.yml` required

---

## 🧩 Additional Notes

Anything else the reviewer should know.
