### PR TITLE
Default MAX_STRING_LENGTH to aggressive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,10 @@ src/agent/
 - **Authentication**: Never bypass authentication checks; use UnifiedAuthenticationManager for consistent auth handling
 - **Plugin Security**: Plugins must declare required scopes; use allowlist-based validation for plugin loading
 - **Audit Logging**: Log all security events (authentication, authorization, access denials) with appropriate risk levels
+- **Function Argument Sanitization**: Configure `max_string_length` and `sanitization_enabled` in security config to control how function arguments are sanitized:
+  - `max_string_length: 100000` - Default 100KB limit for string arguments (prevents large file content truncation)
+  - `max_string_length: -1` - Disable string length limits entirely (use with caution)
+  - `sanitization_enabled: false` - Disable all argument sanitization (not recommended for production)
 
 ## Task Completion Workflow
 
@@ -263,6 +267,10 @@ security:
     files:write: ["files:read"]
     api:admin: ["api:write", "api:read"]
     api:write: ["api:read"]
+  
+  # Function argument sanitization settings
+  sanitization_enabled: true   # Enable function argument sanitization
+  max_string_length: 100000    # Max string length in chars (100KB default, -1 = unlimited)
 ```
 
 **Important**: Each function requires specific scopes. If a user's API key doesn't have the required scope (either directly or through hierarchy inheritance), access will be denied with a 403 error.

--- a/src/agent/config/model.py
+++ b/src/agent/config/model.py
@@ -313,6 +313,14 @@ class SecurityConfig(BaseModel):
     )
     scope_hierarchy: dict[str, list[str]] = Field(default_factory=dict, description="Scope hierarchy configuration")
 
+    # Function argument sanitization settings
+    max_string_length: int = Field(
+        default=100000,
+        description="Maximum allowed string length in function arguments (in characters). Set to -1 to disable limit.",
+        ge=-1,
+    )
+    sanitization_enabled: bool = Field(default=True, description="Enable function argument sanitization for security")
+
     @field_validator("scope_hierarchy", mode="before")
     @classmethod
     def validate_scope_hierarchy(cls, v):

--- a/src/agent/templates/config/agentup.yml.j2
+++ b/src/agent/templates/config/agentup.yml.j2
@@ -212,6 +212,10 @@ security:
 {% if has_mcp %}
     weather:admin: ["alerts:read", "weather:read"]
 {% endif %}
+  
+  # Function argument sanitization settings
+  sanitization_enabled: {{ sanitization_enabled | default(true) }}  # Enable function argument sanitization
+  max_string_length: {{ max_string_length | default(100000) }}      # Max string length in chars (100KB default, -1 = unlimited)
 {% endif %}
 
 {%- if ai_provider_config %}


### PR DESCRIPTION
We had a `MAX_STRING_LENGTH` of 1000 which was lopping off deep research reports, changed to the more sensible `100000` (100KB)
