### PR TITLE
Consolidate configuration

### DIFF
--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -15,7 +15,6 @@ __version__ = get_version()
 # Lazy imports to avoid loading config when using CLI
 # Import these explicitly when needed:
 # from agent.api.app import app, create_app, main
-# from agent.config import Config
 # from agent.core import AgentExecutor, FunctionDispatcher, FunctionExecutor
 # from agent.services import get_services, initialize_services
 # from agent.state import ConversationManager, get_context_manager
@@ -29,8 +28,6 @@ __all__ = [
     "AgentExecutor",
     "FunctionDispatcher",
     "FunctionExecutor",
-    # Config
-    "Config",
     # Services
     "get_services",
     "initialize_services",
@@ -53,10 +50,6 @@ def __getattr__(name):
         from .api.app import main
 
         return main
-    elif name == "Config":
-        from .config import Config
-
-        return Config
     elif name == "AgentExecutor":
         from .core import AgentUpExecutor
 

--- a/src/agent/api/__init__.py
+++ b/src/agent/api/__init__.py
@@ -1,5 +1,4 @@
-# Import commonly used functions for backwards compatibility
-from agent.config import Config
+# Import commonly used functions
 from agent.security.decorators import protected
 
 from .app import app, create_app, main
@@ -20,6 +19,5 @@ __all__ = [
     "router",
     "set_request_handler_instance",
     "sse_generator",
-    "Config",
     "protected",
 ]

--- a/src/agent/api/routes.py
+++ b/src/agent/api/routes.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from agent.a2a.agentcard import create_agent_card
+from agent.dependencies import ConfigDep
 from agent.push.types import (
     DeleteTaskPushNotificationConfigRequest,
     DeleteTaskPushNotificationConfigResponse,
@@ -28,7 +29,6 @@ from agent.push.types import (
     listTaskPushNotificationConfigResponse,
 )
 from agent.security import AuthContext, get_auth_result, protected
-from agent.services.config import ConfigurationManager
 
 # Setup logger
 logger = structlog.get_logger(__name__)
@@ -80,13 +80,12 @@ async def get_task_status(task_id: str, request: Request) -> JSONResponse:
 
 
 @router.get("/health")
-async def health_check() -> JSONResponse:
-    config_manager = ConfigurationManager()
+async def health_check(config: ConfigDep) -> JSONResponse:
     return JSONResponse(
         status_code=200,
         content={
             "status": "healthy",
-            "agent": config_manager.get("project_name", "Agent"),
+            "agent": config.project_name,
             "timestamp": datetime.now().isoformat(),
         },
     )

--- a/src/agent/config/__init__.py
+++ b/src/agent/config/__init__.py
@@ -2,10 +2,9 @@ from .a2a import *  # noqa: F403
 from .constants import *  # noqa: F403
 from .model import *  # noqa: F403
 from .plugin_resolver import clear_plugin_resolver, get_plugin_resolver, initialize_plugin_resolver
-from .settings import Config, get_config, get_settings
+from .settings import get_config, get_settings
 
 __all__ = [
-    "Config",
     "get_config",
     "get_settings",
     "get_plugin_resolver",

--- a/src/agent/config/settings.py
+++ b/src/agent/config/settings.py
@@ -252,18 +252,3 @@ def get_settings() -> Settings:
 def get_config() -> Settings:
     """Get the global configuration instance, loading it if necessary."""
     return get_settings()
-
-
-# For backward compatibility, provide Config as a property-like access
-class ConfigProxy:
-    def __getattr__(self, name):
-        return getattr(get_config(), name)
-
-    def __getitem__(self, key):
-        return get_config()[key]
-
-    def get(self, key, default=None):
-        return get_config().get(key, default)
-
-
-Config = ConfigProxy()

--- a/src/agent/core/dispatcher.py
+++ b/src/agent/core/dispatcher.py
@@ -250,14 +250,15 @@ class FunctionRegistry:
         return tools
 
     def _get_mcp_tools(self, scope_service, user_scopes: set[str]) -> list[dict[str, Any]]:
-        from agent.config import Config
+        from agent.config import get_settings
 
         tools = []
+        config = get_settings()
 
-        if not Config.mcp.client_enabled:
+        if not config.mcp.client_enabled:
             return tools
 
-        servers = Config.mcp.servers
+        servers = config.mcp.servers
 
         # Extract tool scopes from server configuration
         from agent.mcp_support.mcp_integration import _extract_tool_scopes_from_servers

--- a/src/agent/core/strategies/reactive.py
+++ b/src/agent/core/strategies/reactive.py
@@ -31,12 +31,13 @@ class ReactiveStrategy(AgentExecutorBase):
         super().__init__(agent)
 
         # Load plugin configuration for direct routing
-        from agent.config import Config
+        from agent.config import get_settings
 
+        config = get_settings()
         self.plugins = {}
         # Handle dictionary-based plugin structure
-        if hasattr(Config, "plugins") and isinstance(Config.plugins, dict):
-            for package_name, plugin_data in Config.plugins.items():
+        if hasattr(config, "plugins") and isinstance(config.plugins, dict):
+            for package_name, plugin_data in config.plugins.items():
                 if plugin_data.get("enabled", True):
                     plugin_name = plugin_data.get("name", package_name)
                     keywords = plugin_data.get("keywords", [])

--- a/src/agent/dependencies.py
+++ b/src/agent/dependencies.py
@@ -1,0 +1,86 @@
+"""
+FastAPI dependency providers for AgentUp.
+
+This module provides dependency injection functions for FastAPI routes,
+enabling proper separation of concerns and testability.
+"""
+
+from functools import lru_cache
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from .config.settings import Settings, get_settings
+from .security import AuthContext, AuthenticationResult, get_auth_result
+
+
+@lru_cache
+def get_config_dependency() -> Settings:
+    """
+    FastAPI dependency provider for configuration.
+
+    Returns the cached global settings instance with full Pydantic validation.
+    This replaces the need for ConfigurationManager or direct Config access.
+
+    Usage in FastAPI routes:
+        @router.get("/example")
+        async def example(config: Settings = Depends(get_config_dependency)):
+            return {"agent_name": config.project_name}
+
+    Returns:
+        Settings: The global configuration instance
+    """
+    return get_settings()
+
+
+def get_auth_context_dependency(request: Request) -> AuthenticationResult | None:
+    """
+    FastAPI dependency provider for authentication context.
+
+    Extracts the authentication result from the request state, which is
+    set by the @protected decorator during request processing.
+
+    Args:
+        request: The FastAPI request object
+
+    Returns:
+        AuthResult | None: The authentication result if available
+    """
+    try:
+        return get_auth_result(request)
+    except Exception:
+        return None
+
+
+# Type aliases for cleaner dependency injection
+ConfigDep = Annotated[Settings, Depends(get_config_dependency)]
+AuthDep = Annotated[AuthenticationResult | None, Depends(get_auth_context_dependency)]
+
+
+def create_auth_context(auth_result: AuthenticationResult | None) -> AuthContext | None:
+    """
+    Helper function to create AuthContext from AuthResult.
+
+    Args:
+        auth_result: The authentication result
+
+    Returns:
+        AuthContext | None: The auth context if auth_result is available
+    """
+    if auth_result is None:
+        return None
+    return AuthContext(auth_result)
+
+
+# Utility functions for backward compatibility
+def get_config() -> Settings:
+    """
+    Direct configuration access (for migration from ConfigurationManager).
+
+    This provides a direct way to get configuration without FastAPI dependency
+    injection, useful during migration from ConfigurationManager usage.
+
+    Returns:
+        Settings: The global configuration instance
+    """
+    return get_config_dependency()

--- a/src/agent/middleware/implementation.py
+++ b/src/agent/middleware/implementation.py
@@ -227,9 +227,9 @@ def get_global_cache_config() -> CacheConfig:
     global _global_cache_config
     if _global_cache_config is None:
         try:
-            from agent.config import Config
+            from agent.config import get_settings
 
-            middleware_config = Config.middleware.model_dump()
+            middleware_config = get_settings().middleware.model_dump()
             cache_params = {}
             if isinstance(middleware_config, dict) and middleware_config.get("caching", {}).get("enabled", False):
                 caching_section = middleware_config.get("caching", {})

--- a/src/agent/plugins/integration.py
+++ b/src/agent/plugins/integration.py
@@ -72,9 +72,9 @@ def integrate_plugins_with_capabilities(
 
     # If config is not provided, load it
     if config is None:
-        from agent.config import Config
+        from agent.config import get_settings
 
-        config = Config
+        config = get_settings()
 
     registered_count = 0
     capabilities_to_register = {}  # capability_id -> scope_requirements
@@ -222,9 +222,9 @@ def get_plugin_adapter():
     """Get the plugin adapter instance."""
     global _plugin_adapter_instance
     if _plugin_adapter_instance is None:
-        from agent.config import Config
+        from agent.config import get_settings
 
-        _plugin_adapter_instance = PluginAdapter(Config)
+        _plugin_adapter_instance = PluginAdapter(get_settings())
     return _plugin_adapter_instance
 
 

--- a/src/agent/plugins/manager.py
+++ b/src/agent/plugins/manager.py
@@ -61,9 +61,9 @@ class PluginRegistry:
         """Get configuration, loading it if needed"""
         if self._config is None:
             try:
-                from agent.config import Config
+                from agent.config import get_settings
 
-                self._config = Config.model_dump()
+                self._config = get_settings().model_dump()
             except ImportError as e:
                 logger.error("Failed to load configuration module")
                 raise ImportError("Configuration module not found. Ensure 'agent.config' is available") from e
@@ -658,9 +658,9 @@ def get_plugin_registry() -> PluginRegistry:
         # Try to load configuration for the plugin registry
         config = None
         try:
-            from agent.config import Config
+            from agent.config import get_settings
 
-            config = Config.model_dump()
+            config = get_settings().model_dump()
         except ImportError:
             logger.debug("Could not load configuration for plugin registry")
 

--- a/src/agent/security/manager.py
+++ b/src/agent/security/manager.py
@@ -20,10 +20,11 @@ class SecurityManager:
     """
 
     def __init__(self):
-        from agent.config import Config
+        from agent.config import get_settings
 
         # Store config references
-        self.config = Config.model_dump()
+        config = get_settings()
+        self.config = config.model_dump()
         self.security_config = self.config.get("security", {})
         self.auth_enabled = self.security_config.get("enabled", False)
 

--- a/src/agent/security/validators.py
+++ b/src/agent/security/validators.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from agent.config import Config
+from agent.config import get_settings
 from agent.config.model import ApiKeyConfig, BearerConfig, JWTConfig, OAuth2Config
 
 from .exceptions import SecurityConfigurationException
@@ -10,7 +10,7 @@ from .exceptions import SecurityConfigurationException
 class SecurityConfigValidator:
     def __init__(self):
         # This class does not need to maintain state, so no instance variables are needed
-        self.security_config = Config.security
+        self.security_config = get_settings().security
 
     # Cache for weak patterns to avoid reading file multiple times
     _weak_patterns_cache = None

--- a/src/agent/services/__init__.py
+++ b/src/agent/services/__init__.py
@@ -21,7 +21,6 @@ Legacy Services (for backwards compatibility):
 
 # New service layer
 # Legacy services for backwards compatibility
-from agent.config import Config
 
 from .base import Service
 from .bootstrap import AgentBootstrapper

--- a/src/agent/services/agent_registration.py
+++ b/src/agent/services/agent_registration.py
@@ -40,23 +40,25 @@ class AgentRegistrationClient(Service):
         self.logger.debug("Initializing agent registration service")
 
         # Get the Pydantic config object
-        from agent.config import Config
+        from agent.config import get_settings
+
+        settings = get_settings()
 
         # Check if orchestrator is configured
-        if not Config.orchestrator:
+        if not settings.orchestrator:
             self.logger.debug("No orchestrator configured, skipping registration")
             self._initialized = True
             return
 
         # Convert Pydantic HttpUrl to string
-        self.orchestrator_url = str(Config.orchestrator)
+        self.orchestrator_url = str(settings.orchestrator)
 
         # Get agent information using Pydantic attributes
-        agent_info = {"name": Config.project_name, "version": Config.version, "description": Config.description}
+        agent_info = {"name": settings.project_name, "version": settings.version, "description": settings.description}
 
         # Determine agent URL from API config
-        host = Config.api.host
-        port = Config.api.port
+        host = settings.api.host
+        port = settings.api.port
 
         # Handle different host configurations for agent URL
         # Bandit: We are converting from 0.0.0.0, so false postive.

--- a/src/agent/services/base.py
+++ b/src/agent/services/base.py
@@ -65,4 +65,18 @@ class Service(ABC):
         Returns:
             Configuration value or default
         """
-        return self.config.get(key, default)
+        # Handle nested keys like "a.b.c"
+        if "." in key:
+            keys = key.split(".")
+            value = self.config
+            for k in keys:
+                if hasattr(value, k):
+                    value = getattr(value, k)
+                elif isinstance(value, dict) and k in value:
+                    value = value[k]
+                else:
+                    return default
+            return value
+
+        # Handle simple keys
+        return getattr(self.config, key, default)

--- a/src/agent/services/llm/manager.py
+++ b/src/agent/services/llm/manager.py
@@ -21,10 +21,11 @@ class LLMManager:
     @staticmethod
     async def get_llm_service(services=None):
         try:
-            from agent.config import Config
+            from agent.config import get_settings
 
             # Get the new ai_provider configuration
-            ai_provider_config = Config.ai_provider
+            config = get_settings()
+            ai_provider_config = config.ai_provider
             if not ai_provider_config:
                 logger.warning("ai_provider not configured in agentup.yml")
                 return None

--- a/src/agent/services/mcp.py
+++ b/src/agent/services/mcp.py
@@ -21,8 +21,8 @@ class MCPService(Service):
     async def initialize(self) -> None:
         self.logger.debug("Initializing MCP service")
 
-        mcp_config = self.config.get("mcp", {})
-        if not mcp_config.get("enabled", False):
+        mcp_config = getattr(self.config, "mcp", None)
+        if not mcp_config or not getattr(mcp_config, "enabled", False):
             self.logger.info("MCP integration disabled")
             self._initialized = True
             return
@@ -31,7 +31,7 @@ class MCPService(Service):
             # Initialize MCP integration using existing code
             from agent.mcp_support.mcp_integration import initialize_mcp_integration
 
-            await initialize_mcp_integration(self.config.config)
+            await initialize_mcp_integration(self.config.model_dump())
 
             self._initialized = True
 

--- a/src/agent/services/registry.py
+++ b/src/agent/services/registry.py
@@ -3,7 +3,7 @@ from typing import Any
 import structlog
 from pydantic import BaseModel, Field
 
-from agent.config import Config
+from agent.config import get_settings
 from agent.config.model import AgentConfig, ServiceConfig
 from agent.llm_providers.anthropic import AnthropicProvider
 from agent.llm_providers.ollama import OllamaProvider
@@ -169,7 +169,7 @@ class ServiceRegistry(BaseModel):
     factories: dict[str, Any] = Field(default_factory=dict, exclude=True, description="Service factories")
 
     def __init__(self, config: AgentConfig | None = None, **data):
-        raw = Config.model_dump() if config is None else config.model_dump()
+        raw = get_settings().model_dump() if config is None else config.model_dump()
         # Filter out orchestrator field which only exists in Settings, not AgentConfig
         raw.pop("orchestrator", None)
         # Handle ai_provider conversion from Settings (which can be None) to AgentConfig (which expects dict)

--- a/src/agent/services/security.py
+++ b/src/agent/services/security.py
@@ -18,11 +18,12 @@ class SecurityService(Service):
 
         try:
             # Create security manager using existing implementation
-            from agent.config import Config
+            from agent.config import get_settings
             from agent.security import create_security_manager, set_global_security_manager
 
             # Pass the full config as dictionary for backward compatibility
-            config_dict = Config.model_dump()
+            config = get_settings()
+            config_dict = config.model_dump()
             self._security_manager = create_security_manager(config_dict)
             set_global_security_manager(self._security_manager)
 

--- a/src/agent/state/conversation.py
+++ b/src/agent/state/conversation.py
@@ -26,9 +26,10 @@ class ConversationManager:
 
     async def prepare_llm_conversation(self, task) -> list[dict[str, str]]:
         """Prepare LLM conversation from A2A task history AND stored conversation state."""
-        from agent.config import Config
+        from agent.config import get_settings
 
-        ai_config = Config.ai
+        config = get_settings()
+        ai_config = config.ai
         system_prompt = ai_config.get(
             "system_prompt",
             """You are an AI agent with access to specific functions/skills.

--- a/tests/test_agent_registration.py
+++ b/tests/test_agent_registration.py
@@ -95,27 +95,31 @@ class TestAgentRegistrationClient:
         """Create a registration client with mocked config."""
         return AgentRegistrationClient(mock_config)
 
-    @patch("agent.config.Config")
-    async def test_initialize_without_orchestrator(self, mock_config_class, registration_client):
+    @patch("agent.config.get_settings")
+    async def test_initialize_without_orchestrator(self, mock_get_settings, registration_client):
         """Test initialization when no orchestrator is configured."""
-        # Mock Config to return None for orchestrator
-        mock_config_class.orchestrator = None
+        # Mock settings to return None for orchestrator
+        mock_settings = MagicMock()
+        mock_settings.orchestrator = None
+        mock_get_settings.return_value = mock_settings
 
         await registration_client.initialize()
 
         assert registration_client._initialized is True
         assert registration_client.orchestrator_url is None
 
-    @patch("agent.config.Config")
-    async def test_initialize_with_orchestrator(self, mock_config_class, registration_client):
+    @patch("agent.config.get_settings")
+    async def test_initialize_with_orchestrator(self, mock_get_settings, registration_client):
         """Test initialization with orchestrator configured."""
-        # Mock Config with orchestrator URL
-        mock_config_class.orchestrator = "http://localhost:8050"
-        mock_config_class.project_name = "Test Agent"
-        mock_config_class.version = "1.0.0"
-        mock_config_class.description = "Test description"
-        mock_config_class.api.host = "127.0.0.1"
-        mock_config_class.api.port = 8001
+        # Mock settings with orchestrator URL
+        mock_settings = MagicMock()
+        mock_settings.orchestrator = "http://localhost:8050"
+        mock_settings.project_name = "Test Agent"
+        mock_settings.version = "1.0.0"
+        mock_settings.description = "Test description"
+        mock_settings.api.host = "127.0.0.1"
+        mock_settings.api.port = 8001
+        mock_get_settings.return_value = mock_settings
 
         # Mock the registration method to avoid actual HTTP calls
         with patch.object(
@@ -127,15 +131,17 @@ class TestAgentRegistrationClient:
             assert registration_client.orchestrator_url == "http://localhost:8050"
             assert registration_client.agent_url == "http://localhost:8001"
 
-    @patch("agent.config.Config")
-    async def test_initialize_with_localhost_host(self, mock_config_class, registration_client):
+    @patch("agent.config.get_settings")
+    async def test_initialize_with_localhost_host(self, mock_get_settings, registration_client):
         """Test initialization handles localhost host correctly."""
-        mock_config_class.orchestrator = "http://localhost:8050"
-        mock_config_class.project_name = "Test Agent"
-        mock_config_class.version = "1.0.0"
-        mock_config_class.description = "Test description"
-        mock_config_class.api.host = "0.0.0.0"  # Should convert to localhost
-        mock_config_class.api.port = 8001
+        mock_settings = MagicMock()
+        mock_settings.orchestrator = "http://localhost:8050"
+        mock_settings.project_name = "Test Agent"
+        mock_settings.version = "1.0.0"
+        mock_settings.description = "Test description"
+        mock_settings.api.host = "0.0.0.0"  # Should convert to localhost
+        mock_settings.api.port = 8001
+        mock_get_settings.return_value = mock_settings
 
         with patch.object(
             registration_client, "_register_with_orchestrator", new_callable=AsyncMock, return_value=True
@@ -144,16 +150,18 @@ class TestAgentRegistrationClient:
 
             assert registration_client.agent_url == "http://localhost:8001"
 
-    @patch("agent.config.Config")
-    async def test_initialize_with_failed_registration(self, mock_config_class, registration_client):
+    @patch("agent.config.get_settings")
+    async def test_initialize_with_failed_registration(self, mock_get_settings, registration_client):
         """Test initialization when registration fails."""
-        # Mock Config with orchestrator URL
-        mock_config_class.orchestrator = "http://localhost:8050"
-        mock_config_class.project_name = "Test Agent"
-        mock_config_class.version = "1.0.0"
-        mock_config_class.description = "Test description"
-        mock_config_class.api.host = "127.0.0.1"
-        mock_config_class.api.port = 8001
+        # Mock settings with orchestrator URL
+        mock_settings = MagicMock()
+        mock_settings.orchestrator = "http://localhost:8050"
+        mock_settings.project_name = "Test Agent"
+        mock_settings.version = "1.0.0"
+        mock_settings.description = "Test description"
+        mock_settings.api.host = "127.0.0.1"
+        mock_settings.api.port = 8001
+        mock_get_settings.return_value = mock_settings
 
         # Mock the registration method to return False (failed)
         with patch.object(

--- a/tests/test_cli/test_plugin_list.py
+++ b/tests/test_cli/test_plugin_list.py
@@ -301,8 +301,8 @@ class TestPluginListCommand:
                 assert result.exit_code == 0
 
     def test_config_import_error_handling(self, runner):
-        """Test handling when Config import fails."""
-        with patch("agent.config.Config", side_effect=ImportError):
+        """Test handling when get_settings import fails."""
+        with patch("agent.config.get_settings", side_effect=ImportError):
             with patch("agent.plugins.manager.PluginRegistry") as mock_registry_class:
                 mock_registry = MagicMock()
                 mock_registry.discover_all_available_plugins.return_value = []

--- a/tests/test_plugin_integration.py
+++ b/tests/test_plugin_integration.py
@@ -95,9 +95,11 @@ class TestPluginCapabilityIntegration:
         mock_registry.plugins = {}
         mock_registry.discover_plugins.return_value = None
 
-        with patch("agent.config.Config") as mock_config_class:
-            # The integration code does `config = Config` (not Config()), so we need to set attributes on the class
-            mock_config_class.plugins = []
+        with patch("agent.config.get_settings") as mock_get_settings:
+            # Create a mock settings object with empty plugins
+            mock_settings = Mock()
+            mock_settings.plugins = []
+            mock_get_settings.return_value = mock_settings
 
             # Should handle empty config gracefully
             result = integrate_plugins_with_capabilities(None)


### PR DESCRIPTION
The system currently has two primary ways of accessing configuration:

A global `Config` object imported from `agent.config` A `ConfigurationManager` singleton service (`services/config.py`).

Having two systems for the same purpose is confusing and duplicates logic.

Also global access to configuration (e.g., `from agent.config import Config`) hides the component’s dependencies, making the code harder to test and reason about.

This PR implements a single  way tostandardize on the pydantic-settings `Settings` object (`config/settings.py`) as the single source for all configuration. It already provides robust loading from YAML files and environment variables, plus good validation out of the box.

Closes: #304