### PR TITLE
Settings object has no attribute agent_config

### DIFF
--- a/src/agent/core/function_executor.py
+++ b/src/agent/core/function_executor.py
@@ -220,7 +220,7 @@ class FunctionExecutor:
             from agent.config import get_config
 
             config = get_config()
-            security_config = config.agent_config.security
+            security_config = config.security
 
             # Check if sanitization is disabled
             if not security_config.sanitization_enabled:


### PR DESCRIPTION
get_config() returns a Settings object, which has security as a direct attribute, not nested under agent_config. The code should be:

`security_config = config.security`
